### PR TITLE
552 evaluate file sharing

### DIFF
--- a/controllers/files.js
+++ b/controllers/files.js
@@ -404,19 +404,14 @@ router.get('/classes/:classId', FileGetter, function (req, res, next) {
 });
 
 router.post('/permissions/', function (req, res, next) {
-    api(req).post("/filePermissions/", { json: req.body }).then(filePermission => {
-       res.json(filePermission);
-    }).catch(err => {
-        // if already exists, return existing filePermission
-        if (err.statusCode === 409) {
-            api(req).get("/filePermissions/", {
-                qs: {key: req.body.key}
-            }).then(result => {
-                res.json(result.data[0]);
+    api(req).get('/filePermissions/', { qs: {key: req.body.key} }).then(filePermission => {
+        if (filePermission.data.length > 0) {
+            res.json(filePermission.data[0]);
+        } else {
+            api(req).post("/filePermissions/", { json: req.body }).then(filePermission => {
+                res.json(filePermission);
             });
         }
-
-        res.send(err);
     });
 });
 

--- a/controllers/files.js
+++ b/controllers/files.js
@@ -130,6 +130,28 @@ const getScopeDirs = (req, res, scope) => {
     });
 };
 
+/**
+ * register a new filePermission for the given user for the given file
+ * @param userId {String} - the user which should be granted permission
+ * @param filePath {String} - the file for which a new permission should be created
+ */
+const registerSharedPermission = (userId, filePath, req) => {
+    // check whether a filePermission entry already exist for the given file
+    return api(req).get('/filePermissions/', {qs: {key: filePath}}).then(res => {
+        if (res.data.length <= 0) {
+            // owner permits sharing of given file
+            return Promise.reject("Zu dieser Datei haben Sie keinen Zugriff!");
+        } else {
+            let filePermission = res.data[0];
+            filePermission.permissions.push({
+                userId: userId,
+                permissions: ['can-read', 'can-write'] // todo: make it selectable
+            });
+            return api(req).patch('/filePermissions/' + res.data[0]._id, {json: filePermission});
+        }
+    });
+};
+
 
 // secure routes
 router.use(authHelper.authChecker);
@@ -207,7 +229,7 @@ router.delete('/file', function (req, res, next) {
 // get file
 router.get('/file', function (req, res, next) {
 
-    const {file, download = false, path} = req.query;
+    const {file, download = false, path, shared = false} = req.query;
 
     const basePath = getStorageContext(req, res, {url: req.get('Referrer')});
     const data = {
@@ -216,15 +238,19 @@ router.get('/file', function (req, res, next) {
         action: 'getObject'
     };
 
-    requestSignedUrl(req, data).then(signedUrl => {
-        return rp.get(signedUrl.url, {encoding: null}).then(awsFile => {
-            if (download) {
-                res.type('application/octet-stream');
-                res.set('Content-Disposition', 'attachment;filename=' + pathUtils.basename(file));
-            } else if (signedUrl.header['Content-Type']) {
-                res.type(signedUrl.header['Content-Type']);
-            }
-            res.end(awsFile, 'binary');
+    let sharedPromise = shared ? registerSharedPermission(res.locals.currentUser._id, data.path, req) : Promise.resolve();
+    sharedPromise.then(_ => {
+        return requestSignedUrl(req, data).then(signedUrl => {
+            return rp.get(signedUrl.url, {encoding: null}).then(awsFile => {
+                if (download) {
+                    res.type('application/octet-stream');
+                    res.set('Content-Disposition', 'attachment;filename=' + pathUtils.basename(file));
+                } else if (signedUrl.header['Content-Type']) {
+                    res.type(signedUrl.header['Content-Type']);
+                }
+
+                res.end(awsFile, 'binary');
+            });
         });
     }).catch(err => {
         res.status((err.statusCode || 500)).send(err);

--- a/controllers/files.js
+++ b/controllers/files.js
@@ -403,5 +403,22 @@ router.get('/classes/:classId', FileGetter, function (req, res, next) {
     });
 });
 
+router.post('/permissions/', function (req, res, next) {
+    api(req).post("/filePermissions/", { json: req.body }).then(filePermission => {
+       res.json(filePermission);
+    }).catch(err => {
+        // if already exists, return existing filePermission
+        if (err.statusCode === 409) {
+            api(req).get("/filePermissions/", {
+                qs: {key: req.body.key}
+            }).then(result => {
+                res.json(result.data[0]);
+            });
+        }
+
+        res.send(err);
+    });
+});
+
 
 module.exports = router;

--- a/static/scripts/files.js
+++ b/static/scripts/files.js
@@ -224,6 +224,45 @@ $moveModal.modal('hide');
         $modals.modal('hide');
     });
 
+    $('.btn-file-share').click(function (e) {
+        e.stopPropagation();
+        e.preventDefault();
+        let path = $(this).attr('data-file-path');
+        let $shareModal = $('.share-modal');
+        $.ajax({
+            type: "POST",
+            url: "/files/permissions/",
+            data: {
+                key: path
+            },
+            success: function(data) {
+                let target = `files/file?path=${data.key}&shared=true`;
+                $.ajax({
+                    type: "POST",
+                    url: "/link/",
+                    data: {
+                        target: target
+                    },
+                    success: function(data) {
+                        populateModalForm($shareModal, {
+                            title: 'Einladungslink generiert!',
+                            closeLabel: 'Schließen',
+                            submitLabel: 'Speichern',
+                            fields: {invitation: data.newUrl}
+                        });
+                        $shareModal.find('.btn-submit').remove();
+                        $shareModal.find("input[name='invitation']").click(function () {
+                            $(this).select();
+                        });
+
+                        $shareModal.modal('show');
+
+                    }
+                });
+            }
+        });
+    });
+
 });
     function videoClick(e) {
         e.stopPropagation();

--- a/views/files/files.hbs
+++ b/views/files/files.hbs
@@ -138,12 +138,11 @@
                                                data-file-path="{{this.path}}">
                                                 <i class="fa fa-trash-o"></i>
                                             </a>
-                                            <a href="/files/file/"
-                                                target="_blank"
-                                                data-method="move"
-                                                data-file-name="{{this.name}}"
-                                                data-file-path="{{this.path}}">
-                                                <!--<i class="fa fa-share"></i>-->
+
+                                            <a href="#"
+                                               class="btn-file-share"
+                                               data-file-path="{{this.key}}">
+                                                <i class="fa fa-share"></i>
                                             </a>
                                             <small class="file-info" id="{{this.name}}"></small>
                                         </div>
@@ -190,6 +189,12 @@
                         Löschen
                     </button>
                 </div>
+            {{/content}}
+        {{/embed}}
+
+        {{#embed "lib/components/modal-form" class="share-modal"}}
+            {{#content "fields"}}
+                {{> "files/forms/form-share-file"}}
             {{/content}}
         {{/embed}}
 

--- a/views/files/forms/form-share-file.hbs
+++ b/views/files/forms/form-share-file.hbs
@@ -1,0 +1,4 @@
+<div class="form-group">
+    <label for="invitation">Verteile folgenden Link, um Zugriff auf die Datei zu gewährleisten. </label>
+    <input class="form-control" name="invitation" type="text" />
+</div>


### PR DESCRIPTION
First merge [Server-PR](https://github.com/schul-cloud/schulcloud-server/pull/174)

Simple way for sharing files. Creates a tiny-link, with which other users can create a permission for the give file. More logic (like read-write permissions, disable sharing, show all shared files in a folder etc.) will be implemented later on.