### PR TITLE
add mailto link for reporting external content

### DIFF
--- a/static/styles/content/content.scss
+++ b/static/styles/content/content.scss
@@ -29,6 +29,7 @@ h1, h3 {
 }
 .card-block {
     flex: 1 1 auto;
+    padding-bottom: 36px;
 }
 .row.equal-height {
     display: flex;
@@ -80,4 +81,19 @@ h1, h3 {
 }
 .tooltip-arrow{
   background-color: $colorHPIRed;
+}
+.tooltip-demo{
+  cursor: pointer;
+}
+.card-footer{
+  position: relative;
+}
+.report-link{
+  position: absolute;
+  top: -34px;
+  right: 18px;
+  color: lightgrey;
+}
+.report-link:hover{
+  color: $colorHPIRed;
 }

--- a/static/styles/content/content.scss
+++ b/static/styles/content/content.scss
@@ -94,6 +94,3 @@ h1, h3 {
   right: 18px;
   color: lightgrey;
 }
-.report-link:hover{
-  color: $colorHPIRed;
-}

--- a/views/content/item.hbs
+++ b/views/content/item.hbs
@@ -29,6 +29,11 @@
     </div>
     <div class="card-footer text-muted w-100">
         <span>via {{{ providerName }}}</span>
+        {{#userIsAllowedToViewContent nonOer}}
+          <a class="pull-right" href="mailto:inhalte@schul-cloud.org?Subject=Melden%20des%20Inhaltes%20mit%20der%20ID%20{{{ ../_id }}}&body=Liebes%20Schul-Cloud%20Team%2C%0Ahiermit%20m%C3%B6chte%20ich%20den%20im%20Betreff%20genannten%20Inhalt%20melden%2C%20da%3A%0A%5Bhier%20bitte%20Ihre%20Gr%C3%BCnde%5D">melden <i class="fa fa-flag" aria-hidden="true"></i></a>
+        {{else}}
+          <a class="pull-right" href="mailto:inhalte@schul-cloud.org?Subject=Melden%20des%20Inhaltes%20mit%20dem%20Titel%20{{{ ../title }}}&body=Liebes%20Schul-Cloud%20Team%2C%0Ahiermit%20m%C3%B6chte%20ich%20den%20im%20Betreff%20genannten%20Inhalt%20melden%2C%20da%3A%0A%5Bhier%20bitte%20Ihre%20Gr%C3%BCnde%5D">melden <i class="fa fa-flag" aria-hidden="true"></i></a>
+        {{/userIsAllowedToViewContent}}
         {{#userHasPermission "COURSE_EDIT"}}
             <a class="add-to-lesson pull-right" href="{{{ ../_id }}}">
                 <i class="fa fa-plus-square"></i>

--- a/views/content/item.hbs
+++ b/views/content/item.hbs
@@ -26,14 +26,22 @@
             </div>
         {{/userIsAllowedToViewContent}}
 
+
     </div>
     <div class="card-footer text-muted w-100">
-        <span>via {{{ providerName }}}</span>
         {{#userIsAllowedToViewContent nonOer}}
-          <a class="pull-right" href="mailto:inhalte@schul-cloud.org?Subject=Melden%20des%20Inhaltes%20mit%20der%20ID%20{{{ ../_id }}}&body=Liebes%20Schul-Cloud%20Team%2C%0Ahiermit%20m%C3%B6chte%20ich%20den%20im%20Betreff%20genannten%20Inhalt%20melden%2C%20da%3A%0A%5Bhier%20bitte%20Ihre%20Gr%C3%BCnde%5D">melden <i class="fa fa-flag" aria-hidden="true"></i></a>
+            <a class="pull-right report-link"
+                href="mailto:inhalte@schul-cloud.org?Subject=Melden%20des%20Inhaltes%20mit%20der%20ID%20{{{ ../_id }}}&body=Liebes%20Schul-Cloud%20Team%2C%0Ahiermit%20m%C3%B6chte%20ich%20den%20im%20Betreff%20genannten%20Inhalt%20melden%2C%20da%3A%0A%5Bhier%20bitte%20Ihre%20Gr%C3%BCnde%5D">
+                melden <i class="fa fa-flag" aria-hidden="true"></i>
+            </a>
         {{else}}
-          <a class="pull-right" href="mailto:inhalte@schul-cloud.org?Subject=Melden%20des%20Inhaltes%20mit%20dem%20Titel%20{{{ ../title }}}&body=Liebes%20Schul-Cloud%20Team%2C%0Ahiermit%20m%C3%B6chte%20ich%20den%20im%20Betreff%20genannten%20Inhalt%20melden%2C%20da%3A%0A%5Bhier%20bitte%20Ihre%20Gr%C3%BCnde%5D">melden <i class="fa fa-flag" aria-hidden="true"></i></a>
+            <a class="pull-right report-link"
+                href="mailto:inhalte@schul-cloud.org?Subject=Melden%20des%20Inhaltes%20mit%20dem%20Titel%20{{{ ../title }}}&body=Liebes%20Schul-Cloud%20Team%2C%0Ahiermit%20m%C3%B6chte%20ich%20den%20im%20Betreff%20genannten%20Inhalt%20melden%2C%20da%3A%0A%5Bhier%20bitte%20Ihre%20Gr%C3%BCnde%5D">
+                melden <i class="fa fa-flag" aria-hidden="true"></i>
+            </a>
         {{/userIsAllowedToViewContent}}
+
+        <span>via {{{ providerName }}}</span>
         {{#userHasPermission "COURSE_EDIT"}}
             <a class="add-to-lesson pull-right" href="{{{ ../_id }}}">
                 <i class="fa fa-plus-square"></i>
@@ -42,7 +50,6 @@
             {{#userHasPermission  "LESSONS_VIEW"}}
                 {{#userHasPermission "TOOL_NEW_VIEW"}}
                     <i class="fa fa-plus-square pull-right tooltip-demo"
-                       style="cursor: pointer;"
                        data-toggle="tooltip"
                        data-placement="bottom"
                        data-html="true"


### PR DESCRIPTION
#484 
if logged in as teacher there is a + symbol to add the content to a course right next to the report link. how should I fix this layout problem? center the +?
![screenshot from 2017-11-10 12-55-26](https://user-images.githubusercontent.com/12249958/32657565-8ea6fe6a-c616-11e7-8074-9cf0d06383e6.png)
