### PR TITLE
Send exception hits for error pages.

### DIFF
--- a/helpers/googleAnalytics.js
+++ b/helpers/googleAnalytics.js
@@ -89,13 +89,21 @@ const middleware = (req, res, next) => {
         ua: req.headers['user-agent'], // User agent override
         uip: anonymizeIp(req.ip), // IP override
       };
+
+      // If page is error page, send exception hit instead of pageview hit
+      if(res.locals.error) {
+        hit.t = 'exception';
+        hit.exd = res.locals.error.message;
+      }
+
+      // Custom dimensions
       if(res.locals.currentSchoolData) {
         hit.cd1 = res.locals.currentSchoolData.name;
       }
       if(res.locals.currentUser) {
         hit.cd2 = res.locals.currentUser.gender;
         hit.cd4 = res.locals.currentUser.roles[0].name;
-        hit.cd5 = res.locals.currentRole == 'Demo' ? 1 : 0;
+        hit.cd5 = res.locals.currentRole === 'Demo' ? 1 : 0;
       }
 
       emit(hit);


### PR DESCRIPTION
If a request results in an error page, it is sent as exception hit to Google Analytics. 