### PR TITLE
Fix search pagination, use $limit & $skip

### DIFF
--- a/views/content/search-results.hbs
+++ b/views/content/search-results.hbs
@@ -22,12 +22,10 @@
             </div>
 
             <div class="row equal-height">
-                {{#each searchResults}}
-                    {{#with _source}}
-                        <div class="col-md-6 col-lg-4">
-                            {{> "content/item" }}
-                        </div>
-                    {{/with}}
+                {{#each searchResults.data}}
+                    <div class="col-md-6 col-lg-4">
+                        {{> "content/item" }}
+                    </div>
                 {{/each}}
             </div>
             <div class="row">


### PR DESCRIPTION
Only works with schulcloud-content branch [fix-search-pagination](https://github.com/schul-cloud/schulcloud-content/tree/fix-search-pagination)