### PR TITLE
use polling for gulp watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,7 +34,7 @@ const baseScripts = [
 const getGulpTask = (src, isWatch = false) => {
     let task = gulp.src(src);
     if(isWatch) {
-        task = task.pipe(watch(src));
+        task = task.pipe(watch(src, {interval: 1000, usePolling: true}));
     }
     return task
         .pipe(filelog())


### PR DESCRIPTION
This fixes the not working gulp rebuild after file changes in the docker containerion Docker for Windows.