### PR TITLE
Enable trust proxy config.

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,7 @@ const handlebarsWax = require('handlebars-wax');
 
 const app = express();
 app.use(compression());
+app.set('trust proxy', true);
 
 // view engine setup
 const handlebarsHelper = require('./helpers/handlebars');


### PR DESCRIPTION
Since the client is behind a load balancer, the ip of the request is not the one of the user. By enabling the `trust proxy` config option, the user ip is extracted from the `X-Forwarded-For` header instead.
This is needed for the google analytics tracking.