### PR TITLE
SC-116  ~ Umlaute erlauben File Upload

### DIFF
--- a/controllers/files.js
+++ b/controllers/files.js
@@ -133,7 +133,7 @@ const FileGetter = (req, res, next) => {
         let {files, directories} = data;
 
         files = files.map(file => {
-            file.file = pathUtils.join(file.path, file.name);
+            file.file = file.key;
             return file;
         });
 
@@ -307,6 +307,7 @@ router.get('/file', function (req, res, next) {
     let sharedPromise = share && share !== 'undefined' ? registerSharedPermission(res.locals.currentUser._id, data.path, share, req) : Promise.resolve();
     sharedPromise.then(_ => {
         return requestSignedUrl(req, data).then(signedUrl => {
+            console.log(signedUrl); // todo: here a wrong signed-url is processed!
             return rp.get(signedUrl.url, {encoding: null}).then(awsFile => {
                 if (download && download !== 'undefined') {
                     res.type('application/octet-stream');
@@ -377,6 +378,7 @@ router.delete('/directory', function (req, res) {
 router.get('/my/', FileGetter, function (req, res, next) {
     let files = res.locals.files.files;
     files.map(file => {
+        console.log(file);
         let ending = file.name.split('.').pop();
         file.thumbnail = thumbs[ending] ? thumbs[ending] : thumbs['default'];
     });

--- a/static/scripts/files.js
+++ b/static/scripts/files.js
@@ -78,10 +78,6 @@ $(document).ready(function() {
 
                 this.options.url = file.signedUrl.url;
                 this.options.headers = file.signedUrl.header;
-                this.options.headers['x-amz-meta-name'] = encodeURIComponent(file.name);
-                this.options.headers['x-amz-meta-flat-name'] = encodeURIComponent(this.options.headers['x-amz-meta-flat-name']);
-
-                console.log(this.options);
             });
 
             this.on("sending", function (file, xhr, formData) {
@@ -167,8 +163,7 @@ $(document).ready(function() {
                 url: $buttonContext.attr('href'),
                 type: 'DELETE',
                 data: {
-                    name: $buttonContext.data('file-name'),
-                    dir: $buttonContext.data('file-path')
+                    key: $buttonContext.data('file-key'),
                 },
                 success: function (result) {
                     reloadFiles();
@@ -412,7 +407,6 @@ function videoClick(e) {
 
 function fileViewer(filetype, file, key) {
     $('#my-video').css("display","none");
-    console.log(file);
     switch (filetype) {
         case 'application/pdf':
             $('#file-view').hide();

--- a/static/scripts/files.js
+++ b/static/scripts/files.js
@@ -78,6 +78,10 @@ $(document).ready(function() {
 
                 this.options.url = file.signedUrl.url;
                 this.options.headers = file.signedUrl.header;
+                this.options.headers['x-amz-meta-name'] = encodeURIComponent(file.name);
+                this.options.headers['x-amz-meta-flat-name'] = encodeURIComponent(this.options.headers['x-amz-meta-flat-name']);
+
+                console.log(this.options);
             });
 
             this.on("sending", function (file, xhr, formData) {
@@ -115,7 +119,7 @@ $(document).ready(function() {
 
                 // post file meta to proxy file service for persisting data
                 $.post('/files/fileModel', {
-                    key: file.signedUrl.header['x-amz-meta-path'] + '/' + file.name,
+                    key: file.signedUrl.header['x-amz-meta-path'] + '/' + encodeURIComponent(file.name),
                     path: file.signedUrl.header['x-amz-meta-path'] + '/',
                     name: file.name,
                     type: file.type,
@@ -408,6 +412,7 @@ function videoClick(e) {
 
 function fileViewer(filetype, file, key) {
     $('#my-video').css("display","none");
+    console.log(file);
     switch (filetype) {
         case 'application/pdf':
             $('#file-view').hide();
@@ -440,7 +445,6 @@ function fileViewer(filetype, file, key) {
             let gviewer ="https://docs.google.com/viewer?url=";
             $openModal.find('.modal-title').text("Möchtest du diese Datei mit dem externen Dienst Google Docs Viewer ansehen?");
             file = file.substring(file.lastIndexOf('/')+1);
-
             $.post('/files/file?file=', {
                 path: (getCurrentDir()) ? getCurrentDir() + file : key,
                 type: filetype,

--- a/static/scripts/files.js
+++ b/static/scripts/files.js
@@ -163,7 +163,7 @@ $(document).ready(function() {
                 url: $buttonContext.attr('href'),
                 type: 'DELETE',
                 data: {
-                    key: $buttonContext.data('file-key'),
+                    key: $buttonContext.data('file-key')
                 },
                 success: function (result) {
                     reloadFiles();

--- a/static/scripts/files.js
+++ b/static/scripts/files.js
@@ -405,7 +405,7 @@ function videoClick(e) {
     e.preventDefault();
 }
 
-function fileViewer(filetype, file, key) {
+function fileViewer(filetype, file, key, name) {
     $('#my-video').css("display","none");
     switch (filetype) {
         case 'application/pdf':
@@ -437,10 +437,10 @@ function fileViewer(filetype, file, key) {
         case 'text/plain': //only in Google Docs Viewer                                     //.txt
             $('#file-view').css('display','');
             let gviewer ="https://docs.google.com/viewer?url=";
+            let showAJAXError = showAJAXError; // for deeply use
             $openModal.find('.modal-title').text("Möchtest du diese Datei mit dem externen Dienst Google Docs Viewer ansehen?");
-            file = file.substring(file.lastIndexOf('/')+1);
             $.post('/files/file?file=', {
-                path: (getCurrentDir()) ? getCurrentDir() + file : key,
+                path: (getCurrentDir()) ? getCurrentDir() + name : key,
                 type: filetype,
                 action: "getObject"
             }, function (data) {

--- a/static/scripts/homework.js
+++ b/static/scripts/homework.js
@@ -296,7 +296,7 @@ $(document).ready(function() {
 
                 // post file meta to proxy file service for persisting data
                 $.post('/files/fileModel', {
-                    key: file.signedUrl.header['x-amz-meta-path'] + '/' + file.name,
+                    key: file.signedUrl.header['x-amz-meta-path'] + '/' + encodeURIComponent(file.name),
                     path: file.signedUrl.header['x-amz-meta-path'] + '/',
                     name: file.name,
                     type: file.type,
@@ -363,8 +363,7 @@ $(document).ready(function() {
                 url: $buttonContext.attr('href'),
                 type: 'DELETE',
                 data: {
-                    name: $buttonContext.data('file-name'),
-                    dir: $buttonContext.data('file-path')
+                    key: $buttonContext.data('file-key')
                 },
                 success: function (_) {
                     // delete reference in submission

--- a/views/files/files-grid.hbs
+++ b/views/files/files-grid.hbs
@@ -8,7 +8,7 @@
                     <div class="openFile">
                         <div class="card-block"
                              onclick="location.href='#file-view';
-                                     fileViewer('{{this.type}}', '{{this.file}}','{{this.key}}');">
+                                     fileViewer('{{this.type}}', '{{this.file}}','{{this.key}}','{{this.name}}');">
                             <div class="card-title">
                                 <div class="col-sm-3 no-padding">
                                     <div class="file-preview"

--- a/views/files/files-grid.hbs
+++ b/views/files/files-grid.hbs
@@ -31,8 +31,8 @@
                                 <a href="/files/file/"
                                    target="_blank"
                                    data-method="delete"
+                                   data-file-key="{{../this.key}}"
                                    data-file-name="{{../this.name}}"
-                                   data-file-path="{{../this.path}}">
                                     <i class="fa fa-trash-o"></i>
                                 </a>
                                 {{/userHasPermission}}

--- a/views/homework/components/submission_uploaded_files.hbs
+++ b/views/homework/components/submission_uploaded_files.hbs
@@ -15,7 +15,7 @@
                             target="_blank"
                             data-method="delete-file"
                             data-file-name="{{this.name}}"
-                            data-file-path="{{this.path}}"
+                            data-file-key="{{this.key}}"
                             data-file-id="{{this._id}}">
                         <i class="fa fa-trash-o"></i>
                     </a>


### PR DESCRIPTION
Scheinbar ist es neuerdings so, dass der `xmlhttprequest` Probleme macht, wenn umlaute in den Dateinnamen sind. Das wird durch diesen PR behoben.

[Server-PR](https://github.com/schul-cloud/schulcloud-server/pull/295)