### PR TITLE
Bugfix for deleting course-folders

### DIFF
--- a/controllers/files.js
+++ b/controllers/files.js
@@ -360,7 +360,7 @@ router.post('/directory', function (req, res, next) {
 // delete directory
 router.delete('/directory', function (req, res) {
     const data = {
-        path: req.body.dir
+        path: req.body.key
     };
 
     api(req).delete('/fileStorage/directories/', {

--- a/views/files/files.hbs
+++ b/views/files/files.hbs
@@ -50,7 +50,7 @@
 								   target="_blank"
 								   data-method="delete"
 								   data-file-name="{{../this.name}}"
-								   data-file-path="{{../this.path}}">
+								   data-file-key="{{../this.path}}">
 									<i class="fa fa-trash-o pull-right"></i>
 								</a>
                                 {{/userHasPermission}}


### PR DESCRIPTION
Latest PR #644 reveals in a new bug that prevents deleting course-folders. This PR is fixing it.

fixes SC-162