### PR TITLE
add courseId to request to pass ownership check on server

### DIFF
--- a/controllers/topics.js
+++ b/controllers/topics.js
@@ -158,6 +158,10 @@ router.patch('/:topicId', function(req, res, next) {
     const data = req.body;
     data.time = moment(data.time || 0, 'HH:mm').toString();
     data.date = moment(data.date || 0, 'YYYY-MM-DD').toString();
+    
+    if (!data.courseId && !req.query.courseGroup) {
+        data.courseId = req.params.courseId;
+    }
 
     // if not a simple hidden or position patch, set contents to empty array
     if (!data.contents && !req.query.json) {


### PR DESCRIPTION
On any patch request to a topic, the server checks if the course in the request matches any course of the teacher who made the request.

However, if someone tries to make a topic invisible, no courseId is added to the request, therefore that check always fails, and the server denies any attempt to do so.

This is one way to fix it, and im pretty sure it has no unwanted side effects, but someone should definetly check.

According to my testing the same applies to changes in the ordering of topics, but this change is not enough to fix that as well.