### PR TITLE
also allow coursegroups to be undefined

### DIFF
--- a/controllers/homework.js
+++ b/controllers/homework.js
@@ -807,7 +807,7 @@ router.get('/:assignmentId', function(req, res, next) {
             assignment.submission = (submissions || {}).data.map(submission => {
                 submission.teamMemberIds = submission.teamMembers.map(e => { return e._id; });
                 submission.courseGroupMemberIds = (submission.courseGroupId || {}).userIds;
-                submission.courseGroupMembers = (_.find(courseGroups.data, cg => JSON.stringify(cg._id) === JSON.stringify((submission.courseGroupId || {})._id)) || {}).userIds; // need full user objects here, double populating not possible above
+                submission.courseGroupMembers = (_.find((courseGroups || {}).data, cg => JSON.stringify(cg._id) === JSON.stringify((submission.courseGroupId || {})._id)) || {}).userIds; // need full user objects here, double populating not possible above
                 return submission;
             }).filter(submission => {
                 return ((submission.studentId || {})._id == res.locals.currentUser._id) ||


### PR DESCRIPTION
For private assignments (homework), we're allowing to **not** specify a course ("Keine Zuordnung"). In this case `courseGroups` is `undefined` and we're getting an error when accessing ```.data```. This PR fixes this with ```(courseGroups || {}).data```.