### PR TITLE
SecondaryTitle - SC_Card - fix

### DIFF
--- a/helpers/handlebars/helpers/index.js
+++ b/helpers/handlebars/helpers/index.js
@@ -61,6 +61,9 @@ module.exports = {
     stripHTMLTags: (htmlText = '') => {
         return stripHtml(htmlText);
     },
+    stripOnlyScript: (htmlText = '') => {
+      return stripHtml(htmlText, {onlyStripTags: ['script', 'style']});
+    },
     conflictFreeHtml: (text = '') => {
         text = text.replace(/style=["'][^"]*["']/g,'');
         text = text.replace(/<(a).*?>(.*?)<\/(?:\1)>/g,'$2');

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "serve-favicon": "~2.3.2",
     "shortid": "^2.2.8",
     "showdown": "^1.7.1",
-    "string-strip-html": "^1.1.0",
+    "string-strip-html": "^3.2.0",
     "string_decoder": "^1.0.1",
     "truncate-html": "^1.0.0",
     "winston": "^3.0.0"

--- a/views/files/files-overview.hbs
+++ b/views/files/files-overview.hbs
@@ -15,7 +15,7 @@
                 <div class="sc-card-wrapper col-md-6 col-sm-6 col-xs-12">
                     {{> 'lib/components/sc-card' 
                         title='<i class="fa fa-user"></i> Meine persönlichen Dateien'
-                        secondaryTitle="&nbsp;"
+                        secondaryTitle="<br />"
                         url='/files/my/'
                         link-text='Dateien öffnen'
                         content='Hier findest du alle deine persönlichen Dateien. Auf diese Dateien hast nur du Zugriff, du kannst sie aber auch mit anderen Nutzern teilen.'
@@ -25,7 +25,7 @@
                 <div class="sc-card-wrapper col-md-6 col-sm-6 col-xs-12">
                     {{> 'lib/components/sc-card' 
                         title='<i class="fa fa-graduation-cap"></i> Meine Kurs-Dateien'
-                        secondaryTitle="&nbsp;"
+                        secondaryTitle="<br />"
                         url='/files/courses/'
                         link-text='Dateien öffnen'
                         content='Hier findest du alle Dateien, die in den jeweiligen Kursen im Unterricht verwendet werden. Alle Teilnehmer des Kurses, also der Lehrer und die Schüler, haben auf diese Dateien Zugriff.'
@@ -35,7 +35,7 @@
                 <div class="sc-card-wrapper col-md-6 col-sm-6 col-xs-12">
                     {{> 'lib/components/sc-card' 
                         title='<i class="fa fa-share-alt"></i> Mit mir geteilte Dateien'
-                        secondaryTitle="&nbsp;"
+                        secondaryTitle="<br />"
                         url='/files/shared/'
                         link-text='Dateien öffnen'
                         content='Hier findest du alle mit dir geteilten Dateien. Dies sind Dateien die von anderen Nutzern zur Verfügung gestellt worden sind.'

--- a/views/lib/components/sc-card.hbs
+++ b/views/lib/components/sc-card.hbs
@@ -3,7 +3,7 @@
         <span class="sc-card-title">
             <span class="title">{{this.title}}</span>
             {{#if this.secondaryTitle}}
-                <small class="d-block">{{this.secondaryTitle}}</small>
+                <small class="d-block">{{{ stripOnlyScript this.secondaryTitle }}}</small>
             {{/if}}
         </span>
 

--- a/views/lib/components/sc-card.hbs
+++ b/views/lib/components/sc-card.hbs
@@ -1,7 +1,7 @@
 <article class="sc-card">
     <a href="{{this.url}}" rel="canonical" class="sc-card-header" {{#if this.background}}style="background:{{this.background}};"{{/if}}>
         <span class="sc-card-title">
-            <span class="title">{{this.title}}</span>
+            <span class="title">{{{ stripOnlyScript this.title }}}</span>
             {{#if this.secondaryTitle}}
                 <small class="d-block">{{{ stripOnlyScript this.secondaryTitle }}}</small>
             {{/if}}


### PR DESCRIPTION
render secondary title again, stripping caused newlines to disappear entirely.
As they aren't written in html we couldn't preserve them.
Solution: strip only script tags and style tags.
Only user field is Room, rest is client side