### PR TITLE
[WIP] Use pseudonym for pseudonymous LTI tools

### DIFF
--- a/controllers/tools.js
+++ b/controllers/tools.js
@@ -29,16 +29,15 @@ const createToolHandler = (req, res, next) => {
 const addToolHandler = (req, res, next) => {
     let action = '/courses/' + req.params.courseId + '/tools/add';
 
-    api(req).get('/ltiTools/')
+    api(req).get('/ltiTools', { qs: {isTemplate: true}})
     .then(tools => {
-        const ltiTools = tools.data.filter(ltiTool => ltiTool.isTemplate == 'true');
         api(req).get('/courses/' + req.params.courseId)
             .then(course => {
                 res.render('courses/add-tool', {
                     action,
                     title: 'Tool anlegen für ' + course.name,
                     submitLabel: 'Tool anlegen',
-                    ltiTools,
+                    ltiTools: tools.data,
                     courseId: req.params.courseId
                 });
             });
@@ -48,21 +47,26 @@ const addToolHandler = (req, res, next) => {
 const runToolHandler = (req, res, next) => {
     let currentUser = res.locals.currentUser;
     Promise.all([
-        api(req).get('/ltiTools/' + req.params.ltiToolId),
-        api(req).get('/roles/' + currentUser.roles[0]._id)
-    ]).then(([tool, role]) => {
+      api(req).get('/ltiTools/' + req.params.ltiToolId),
+      api(req).get('/roles/' + currentUser.roles[0]._id),
+      api(req).get('/pseudonym?userId=' + currentUser._id + '&toolId=' + req.params.ltiToolId)
+    ]).then(([tool, role, pseudonym]) => {
        let customer = new ltiCustomer.LTICustomer();
        let consumer = customer.createConsumer(tool.key, tool.secret);
+       let user_id = '';
+       if (tool.privacy_permission === 'pseudonymous') {
+           user_id = pseudonym.data[0].pseudonym;
+       }
        let payload = {
            lti_version: tool.lti_version,
            lti_message_type: tool.lti_message_type,
-           resource_link_id: req.params.courseId  || tool.resource_link_id,
+           resource_link_id: tool.resource_link_id || req.params.courseId,
            roles: customer.mapSchulcloudRoleToLTIRole(role.name),
            launch_presentation_document_target: 'window',
            launch_presentation_locale: 'en',
-           lis_person_name_full: currentUser.displayName || `${currentUser.firstName} ${currentUser.lastName}`,
-           lis_person_contact_email_primary: currentUser.username ? `${currentUser.username}@schul-cloud.org` : 'jbaird@uni.ac.uk',
-           user_id: currentUser._id
+           // lis_person_name_full: currentUser.displayName || `${currentUser.firstName} ${currentUser.lastName}`,
+           // lis_person_contact_email_primary: currentUser.username ? `${currentUser.username}@schul-cloud.org` : 'jbaird@uni.ac.uk',
+           user_id
        };
        tool.customs.forEach((custom) => {
            payload[customer.customFieldToString(custom)] = custom.value;

--- a/static/scripts/tools.js
+++ b/static/scripts/tools.js
@@ -1,4 +1,4 @@
-$(document).ready(function () {
+ $(document).ready(function () {
 
     var $modals = $('.modal');
     var $editModal = $('.edit-modal');


### PR DESCRIPTION
If privacy_permission is set to pseudonymous, the pseudonym is used instead of the user_id. Otherwise no user_id will be transferred because the identity of the user needs to be protected.

Additionally fixes that not all template-tools will be shown if there are many.

Needs backend PR https://github.com/schul-cloud/schulcloud-server/pull/329