### PR TITLE
N21 image fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -209,7 +209,7 @@ gulp.task('build-all', ['images', 'other', 'styles', 'fonts', 'scripts', 'base-s
   'vendor-styles', 'vendor-scripts', 'vendor-assets'
 ]);
 
-gulp.task('build-theme-files', ['styles']);
+gulp.task('build-theme-files', ['styles', 'images']);
 
 //watch and run corresponding task on change, process changed files only
 gulp.task('watch', ['build-all'], () => {


### PR DESCRIPTION
Problem, dass N21 keine Bilder anzeigt: Problem liegt darin, dass wir Docker nutzen und Docker fürs theming nicht nochmal komplett gulp laufen lässt sondern eben nur `build-theme-files` und da dort nur `styles` als nochmal zu bauen angegeben wurde `images` komplett fehlte.