### PR TITLE
F navigation redesign

### DIFF
--- a/static/styles/lib/colors.scss
+++ b/static/styles/lib/colors.scss
@@ -1,3 +1,0 @@
-
-$colorBeige: #e6e2e2;
-$colorGrey: rgba(232, 232, 232, 0.5);

--- a/static/styles/lib/colors.scss
+++ b/static/styles/lib/colors.scss
@@ -1,0 +1,3 @@
+
+$colorBeige: #e6e2e2;
+$colorGrey: rgba(232, 232, 232, 0.5);

--- a/static/styles/lib/loggedin.scss
+++ b/static/styles/lib/loggedin.scss
@@ -3,7 +3,7 @@
 @import "./editor";
 
 body {
-    background-color: white;
+    background-color: $colorWhite;
     overflow-x: hidden;
     -webkit-overflow-scrolling: touch;
     white-space: nowrap;
@@ -77,8 +77,7 @@ aside.nav-sidebar {
     height: 100vh;
     margin: 0;
     color: #727272;
-    background-color: #ffffff;
-    //background-color: #c3c1c1;
+    background-color: $colorWhite;
     border-right: 1px solid rgba(0,0,0,.15);
 
     @include media-breakpoint-down(md) {
@@ -145,7 +144,7 @@ aside.nav-sidebar {
             width: 100%;
             height: 100vh;
             overflow: auto;
-            background: lightgrey;
+            background: white;
             box-shadow: 0 2px 5px rgba(0,0,0,.26);
             transform: translateY(-102%);
             transition: transform .3s ease-in-out;
@@ -186,12 +185,10 @@ aside.nav-sidebar {
                     white-space: nowrap;
 
                     &.child-active {
-                        background-color: #dbd7d7;
                         border-bottom: 1px solid transparent;
                     }
 
                     &.subitem {
-                        background-color: #dbd7d7;
                         height: 40px;
                         line-height: 40px;
                         border-bottom: 1px solid transparent;
@@ -221,17 +218,14 @@ aside.nav-sidebar {
                     }
 
                     &.active {
-                        background: #fff;
+                        background: $colorWhite;
                         color: $primaryColor;
                         border-bottom: 1px solid transparent;
                     }
 
                     &[href]:hover {
-                        //background: #434857;
-                        //color: #fff !important;
-                        background: rgba(0,0,0,0.1);
+                        background: $colorLightGrey;
                         cursor: pointer;
-                        //border-radius: 3px;
                     }
 
                     i.fa {
@@ -510,7 +504,7 @@ footer {
     @include media-breakpoint-down(xs) {
         margin-bottom: 15px;
         padding-left: 50px !important;
-        background: $colorBeige;
+        background: $colorWhite;
         box-shadow: 0 2px 5px rgba(0,0,0,.26);
     }
 
@@ -576,7 +570,7 @@ footer {
             }
 
             &:hover{
-                background-color: rgba(0,0,0,0.1);
+                background-color: $colorLightGrey;
             }
             &:after{
                 display: none;

--- a/static/styles/lib/loggedin.scss
+++ b/static/styles/lib/loggedin.scss
@@ -231,7 +231,7 @@ aside.nav-sidebar {
                         //color: #fff !important;
                         background: rgba(0,0,0,0.1);
                         cursor: pointer;
-                        border-radius: 3px;
+                        //border-radius: 3px;
                     }
 
                     i.fa {

--- a/static/styles/lib/loggedin.scss
+++ b/static/styles/lib/loggedin.scss
@@ -72,12 +72,14 @@ aside.nav-sidebar {
     position: fixed;
     top: 0;
     left: 0;
-    overflow: auto; 
+    overflow: auto;
     width: 240px;
     height: 100vh;
     margin: 0;
     color: #727272;
-    background-color: #c3c1c1;
+    background-color: #ffffff;
+    //background-color: #c3c1c1;
+    border-right: 1px solid rgba(0,0,0,.15);
 
     @include media-breakpoint-down(md) {
         width: 60px;
@@ -176,14 +178,13 @@ aside.nav-sidebar {
                     float: left;
                     height: 60px;
                     line-height: 60px;
-                    border-bottom: 1px solid #adadad;
-                    color: #727272;
+                    color: $fontColor;
                     padding: 0px 20px;
                     font-size: 14px;
                     text-decoration: none;
                     overflow-x: visible;
                     white-space: nowrap;
-    
+
                     &.child-active {
                         background-color: #dbd7d7;
                         border-bottom: 1px solid transparent;
@@ -226,9 +227,11 @@ aside.nav-sidebar {
                     }
 
                     &[href]:hover {
-                        background: #434857;
-                        color: #fff !important;
+                        //background: #434857;
+                        //color: #fff !important;
+                        background: rgba(0,0,0,0.1);
                         cursor: pointer;
+                        border-radius: 3px;
                     }
 
                     i.fa {
@@ -326,7 +329,7 @@ header {
     @include media-breakpoint-down(xs) {
         padding-left: 0px;
     }
-    
+
     .federal-state {
         height: 35px;
         margin-left: 8px !important;
@@ -632,7 +635,7 @@ footer {
     .dropdown-toggle:not(.recent) .tag {
         display: none;
     }
-    
+
     .dropdown-menu{
         width: 300px;
         max-height: 300px;

--- a/static/styles/lib/loggedin.scss
+++ b/static/styles/lib/loggedin.scss
@@ -144,7 +144,7 @@ aside.nav-sidebar {
             width: 100%;
             height: 100vh;
             overflow: auto;
-            background: white;
+            background: $colorWhite;
             box-shadow: 0 2px 5px rgba(0,0,0,.26);
             transform: translateY(-102%);
             transition: transform .3s ease-in-out;

--- a/theme/default/style.scss
+++ b/theme/default/style.scss
@@ -1,7 +1,13 @@
 $primaryColor: #b10438;
 $secondaryColor: #e2661d;
 $accentColor: #f8a41b;
-$logoGradient: linear-gradient(35deg, #b1063a 35%, #f6a800);
 $fontColor: #373a3c;
+
+$logoGradient: linear-gradient(35deg, #b1063a 35%, #f6a800);
+
+$colorBeige: #e6e2e2;
+$colorGrey: rgba(232, 232, 232, 0.5);
+$colorLightGrey: rgba(0,0,0,0.1);
+$colorWhite: #fff;
 
 $logoBackground: url("../../images/logo/cloud-transparent-mono.svg") no-repeat center;

--- a/theme/default/style.scss
+++ b/theme/default/style.scss
@@ -2,5 +2,6 @@ $primaryColor: #b10438;
 $secondaryColor: #e2661d;
 $accentColor: #f8a41b;
 $logoGradient: linear-gradient(35deg, #b1063a 35%, #f6a800);
+$fontColor: #373a3c;
 
 $logoBackground: url("../../images/logo/cloud-transparent-mono.svg") no-repeat center;


### PR DESCRIPTION
new color layout sidenav for desktop and mobile
first reorganisation of a centralised stylesheet for colors

<img width="1326" alt="screenshot 2018-10-25 at 07 45 45" src="https://user-images.githubusercontent.com/7567881/47478588-21acd100-d82a-11e8-8045-1de0d2e9d037.png">
<img width="398" alt="screenshot 2018-10-25 at 07 46 13" src="https://user-images.githubusercontent.com/7567881/47478591-240f2b00-d82a-11e8-8332-428aa780c7f0.png">
<img width="403" alt="screenshot 2018-10-25 at 07 46 26" src="https://user-images.githubusercontent.com/7567881/47478594-26718500-d82a-11e8-90e9-906ed3760726.png">
