### PR TITLE
fix topic edit button link

### DIFF
--- a/views/topic/topic.hbs
+++ b/views/topic/topic.hbs
@@ -74,7 +74,7 @@
                 {{#userHasPermission "COURSE_EDIT"}}
                     <div class="row padding-top">
                         <div class="col-sm-12">
-                            <a href="/{{context}}/{{../courseId}}/topics/{{../_id}}/edit" class="btn btn-add btn-primary">Bearbeiten</a>
+                            <a href="/courses/{{../courseId}}/topics/{{../_id}}/edit" class="btn btn-add btn-primary">Bearbeiten</a>
                             <a href="#"
                             data-href="{{../_id}}"
                             data-courseId="{{../courseId}}"

--- a/views/topic/topic.hbs
+++ b/views/topic/topic.hbs
@@ -74,7 +74,7 @@
                 {{#userHasPermission "COURSE_EDIT"}}
                     <div class="row padding-top">
                         <div class="col-sm-12">
-                            <a href="/courses/{{../courseId}}/topics/{{../_id}}/edit" class="btn btn-add btn-primary">Bearbeiten</a>
+                            <a href="/{{../context}}/{{../courseId}}/topics/{{../_id}}/edit" class="btn btn-add btn-primary">Bearbeiten</a>
                             <a href="#"
                             data-href="{{../_id}}"
                             data-courseId="{{../courseId}}"


### PR DESCRIPTION
don't know why this was changed from /courses to /{{context}} but reverting fixes the problem. maybe check if {{context}} was needed for something else?