### PR TITLE
Hs/fix broken user mgmt if no students/teachers in school

### DIFF
--- a/controllers/administration.js
+++ b/controllers/administration.js
@@ -1084,16 +1084,21 @@ router.all('/students', permissionsHelper.permissionsChecker(['ADMIN_VIEW', 'STU
         qs: query
     }).then(userData => {
         let users = userData.data;
-
+        let consentsPromise;
         const classesPromise = getSelectOptions(req, 'classes', {});
-        const consentsPromise = getSelectOptions(req, 'consents', {
-            userId: {
-                $in: users.map((user) => {
-                    return user._id;
-                })
-            },
-            $limit: itemsPerPage
-        });
+
+        if(users.length > 0) {
+                consentsPromise = getSelectOptions(req, 'consents', {
+                userId: {
+                    $in: users.map((user) => {
+                        return user._id;
+                    })
+                },
+                $limit: itemsPerPage
+            });
+        } else {
+            consentsPromise = Promise.resolve();
+        }
         Promise.all([
             classesPromise,
             consentsPromise

--- a/controllers/administration.js
+++ b/controllers/administration.js
@@ -864,15 +864,20 @@ router.all('/teachers', permissionsHelper.permissionsChecker(['ADMIN_VIEW', 'TEA
         qs: query
     }).then(userData => {
         let users = userData.data;
+        let consentsPromise;
 
         const classesPromise = getSelectOptions(req, 'classes', {});
-        const consentsPromise = getSelectOptions(req, 'consents', {
-            userId: {
-                $in: users.map((user) => {
-                    return user._id;
-                })
-            }
-        });
+        if(users.length > 0) {
+            consentsPromise = getSelectOptions(req, 'consents', {
+                userId: {
+                    $in: users.map((user) => {
+                        return user._id;
+                    })
+                }
+            });
+        } else {
+            consentsPromise = Promise.resolve();
+        }
         Promise.all([
             classesPromise,
             consentsPromise


### PR DESCRIPTION
Schüler-/Lehrerverwaltung war nicht aufrufbar, wenn kein Schüler oder kein Lehrer an der Schule existierte. Das Problembild, dass ein Consent eines nicht mehr existierenden Users Probleme macht, kann eigentlich nicht auftreten. Es werden nur die Consents der User abgefragt, die in dieser Liste stehen. Gelöschte Nutzer stehen nicht mehr in der Nutzerliste, daher auch keine Abfrage auf diese ID. Somit wird es Consentleichen bei gelöschten Nutzern geben aber sie betreffen nicht das Problem der defekten Nutzerverwaltung.