### PR TITLE
calendar:removed event top-bottom borders, and half hour grid

### DIFF
--- a/static/styles/calendar/calendar.scss
+++ b/static/styles/calendar/calendar.scss
@@ -5,10 +5,8 @@
         float: left;
         width: 100%;
 
-        h2 {
-            font-size: 20px;
-            font-weight: 800;
-            line-height: 30px;
+        .fc-time-grid .fc-slats .fc-minor td {
+          border: 0px;
         }
 
         .fc-event {
@@ -34,13 +32,7 @@
             }
 
             &.fc-time-grid-event {
-                border-top: 6px solid $accentColor;
-                border-bottom: 6px solid transparent;
-
                 &.fc-event-cancelled {
-                    border-top: 6px solid transparent;
-                    border-bottom: 6px solid $primaryColor;
-
                     &:after {
                         color: $primaryColor;
                         content: attr(data-status);


### PR DESCRIPTION
![screenshot 2018-12-06 at 16 19 08](https://user-images.githubusercontent.com/7567881/49593515-04643a00-f974-11e8-9626-549071cccbe7.png)
![screenshot 2018-12-06 at 16 27 16](https://user-images.githubusercontent.com/7567881/49593516-04643a00-f974-11e8-9029-6b8c329f72c6.png)
