### PR TITLE
HEL-253 Limits an verschiedenen Stellen entfernen

### DIFF
--- a/controllers/administration.js
+++ b/controllers/administration.js
@@ -1149,7 +1149,7 @@ router.all('/students', permissionsHelper.permissionsChecker(['ADMIN_VIEW', 'STU
 
 const getUsersWithoutConsent = async (req, roleName, classId) => {
     const role = await api(req).get('/roles', { qs: { name: roleName }, $limit: false });
-    const qs = { roles: role.data[0]._id };
+    const qs = { roles: role.data[0]._id, $limit: false };
     
     let users = [];
     

--- a/controllers/administration.js
+++ b/controllers/administration.js
@@ -1186,7 +1186,7 @@ const getUsersWithoutConsent = async (req, roleName, classId) => {
         users = (await api(req).get('/users', { qs, $limit: false })).data;
     }
 
-    const consents = (await api(req).get('/consents', { $limit: false })).data;
+    const consents = (await api(req).get('/consents')).data;
 
     const usersWithoutConsent = users.filter(user => {
         let userWithConsent = consents.find(consent => {

--- a/controllers/administration.js
+++ b/controllers/administration.js
@@ -19,7 +19,7 @@ moment.locale('de');
 
 const getSelectOptions = (req, service, query, values = []) => {
     return api(req).get('/' + service, {
-        qs: query
+		qs: query
     }).then(data => {
         return data.data;
     });
@@ -1295,7 +1295,7 @@ const renderClassEdit = (req, res, next, edit) => {
     api(req).get('/classes/')
         .then(classes => {
             let promises = [
-                getSelectOptions(req, 'users', { roles: ['teacher', 'demoTeacher'], $limit: 1000 }), //teachers
+                getSelectOptions(req, 'users', { roles: ['teacher', 'demoTeacher'], $limit: false }), //teachers
                 getSelectOptions(req, 'years', { $sort: { name: -1 } }),
                 getSelectOptions(req, 'gradeLevels')
             ];
@@ -1395,10 +1395,10 @@ router.delete('/classes/:id', permissionsHelper.permissionsChecker(['ADMIN_VIEW'
 router.get('/classes/:classId/manage', permissionsHelper.permissionsChecker(['ADMIN_VIEW', 'USERGROUP_EDIT'], 'or'), function (req, res, next) {
     api(req).get('/classes/' + req.params.classId, { qs: { $populate: ['teacherIds', 'substitutionIds', 'userIds'] } })
         .then(currentClass => {
-            const classesPromise = getSelectOptions(req, 'classes', { $limit: 1000 }); // TODO limit classes to scope (year before, current and without year)
-            const teachersPromise = getSelectOptions(req, 'users', { roles: ['teacher', 'demoTeacher'], $sort: 'lastName', $limit: 1000 });
-            const studentsPromise = getSelectOptions(req, 'users', { roles: ['student', 'demoStudent'], $sort: 'lastName', $limit: 10000 });
-            const yearsPromise = getSelectOptions(req, 'years', { $limit: 10000 });
+            const classesPromise = getSelectOptions(req, 'classes', { $limit: false }); // TODO limit classes to scope (year before, current and without year)
+            const teachersPromise = getSelectOptions(req, 'users', { roles: ['teacher', 'demoTeacher'], $sort: 'lastName', $limit: false });
+            const studentsPromise = getSelectOptions(req, 'users', { roles: ['student', 'demoStudent'], $sort: 'lastName', $limit: false });
+            const yearsPromise = getSelectOptions(req, 'years', { $limit: false });
 
             Promise.all([
                 classesPromise,

--- a/controllers/teams.js
+++ b/controllers/teams.js
@@ -619,7 +619,7 @@ router.get('/:teamId/members', async function(req, res, next) {
                         path: 'userIds.role',
                     }
                 ],
-                $limit: 2000
+                $limit: false
             }
         });
         course.userIds = course.userIds.filter(user => user.userId);
@@ -643,7 +643,7 @@ router.get('/:teamId/members', async function(req, res, next) {
                 _id: {
                     $nin: courseUserIds
                 },
-                $limit: 2000
+                $limit: false
             }
         })).data;
 


### PR DESCRIPTION
https://ticketsystem.schul-cloud.org/browse/HEL-253
Es gab Limits, die jetzt erstmals an einer N21 Schule mit mehr als 1000 Schülern dazu führte, dass an verschiedenen Stellen nicht alle Nutzer/Schüler angezeigt wurden.
Entfernt bei:
Verwaltung -> Klassen -> Klasse verwalten (Schülerliste)
Verwaltung -> Schüler -> der Text unten "4471 von 4473 Schüler in deiner Klasse benötigen noch die Einverständniserklärung ..." war vorher capped auf 1000 und daher "998 von 4473 Schüler ..." ([HEL-251](https://ticketsystem.schul-cloud.org/browse/HEL-251))
Teams -> Team -> Teilnehmer-Übersicht -> Interne Teilnehmer hinzufügen (Schülerliste)

Wenn ihr eure Datenbank mit ein paar Tausend Nutzer füllen wollt, siehe [DB-Skripte](https://docs.schul-cloud.org/display/Intern/Datenbank-Skripte)
[Allgemeine Limit-Diskussion](https://docs.schul-cloud.org/display/Intern/Architektur) sollten wir im Architektur-Meeting führen