### PR TITLE
add missing quotes for card data-rss

### DIFF
--- a/views/dashboard/components/card_section.hbs
+++ b/views/dashboard/components/card_section.hbs
@@ -9,7 +9,7 @@
         {{/if}}
         <div class="row tasks card-deck-row">
             {{#each content}}
-            <div class="sc-card-wrapper col-xl-3 col-lg-4 col-md-6 col-sm-12" data-rss={{isRSS}} data-id="{{id}}">
+            <div class="sc-card-wrapper col-xl-3 col-lg-4 col-md-6 col-sm-12" data-rss="{{isRSS}}" data-id="{{id}}">
                 {{> 'lib/components/sc-card' link-text=../link-text additionalInfoName=../additionalInfoName}}
             </div>
             {{else}}


### PR DESCRIPTION
fixes a bug where the attribute `data-id` in the sc-card.hbs was wrapper inside `data-rss`