### PR TITLE
AN-62: Link autofill with website

### DIFF
--- a/static/.well-known/assetlinks.json
+++ b/static/.well-known/assetlinks.json
@@ -1,0 +1,17 @@
+[{
+  "relation": ["delegate_permission/common.get_login_creds"],
+  "target": {
+    "namespace": "web",
+    "site": "https://schul-cloud.org"
+  }
+ },
+ {
+  "relation": ["delegate_permission/common.get_login_creds"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "org.schulcloud.mobile",
+    "sha256_cert_fingerprints": [
+      "FA:8E:A7:EC:91:BD:18:D8:CA:11:33:50:1F:5B:A5:AC:86:A8:EC:6D:F8:26:14:52:0D:FF:76:7C:93:9C:52:6B"
+    ]
+  }
+}]


### PR DESCRIPTION
**Issue:** [AN-62: Link autofill with website](https://ticketsystem.schul-cloud.org/browse/AN-62)


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
What is the current behavior of the app? What is the updated/expected behavior with this PR? -->

Android 8.0 and later enables autofill providers to use credentials stored for schul-cloud.org for our Android app as well. This requires the added file to be present at <https://schul-cloud.org/.well-known/assetlinks.json>. Is it enough to just add it to the `./static` folder?

For more information see the [Google Developers guide](https://developers.google.com/identity/smartlock-passwords/android/associate-apps-and-sites#associate_your_app_with_your_website) and the corresponding PR on schul-cloud/schulcloud-mobile-android#159