### PR TITLE
SC-1018-reject-empty-submissions

### DIFF
--- a/static/scripts/homework.js
+++ b/static/scripts/homework.js
@@ -1,4 +1,4 @@
-﻿/* eslint-env CKEDITOR */
+﻿/* global CKEDITOR */
 
 import { softNavigate } from './helpers/navigation';
 

--- a/static/scripts/homework.js
+++ b/static/scripts/homework.js
@@ -1,4 +1,5 @@
 ﻿/* global CKEDITOR */
+/* eslint unicode-bom: "error" */
 
 import { softNavigate } from './helpers/navigation';
 

--- a/static/scripts/homework.js
+++ b/static/scripts/homework.js
@@ -66,6 +66,17 @@ window.addEventListener("DOMContentLoaded", function(){
     document.querySelector(".filter").dispatchEvent(new CustomEvent("getFilter"));
 });
 $(document).ready(function() {
+	CKEDITOR.instances.evaluation.on('change', () => { 
+		const submitButton = document.getElementById('button-save-submission');
+		let content = CKEDITOR.instances.evaluation.document.getBody().getText();
+		if(!content.trim()) {
+			submitButton.disabled = true;
+		}
+		else{
+			submitButton.disabled = false;
+		}
+	});
+
     function showAJAXError(req, textStatus, errorThrown) {
         if (textStatus === "timeout") {
             $.showNotification("Zeitüberschreitung der Anfrage", "danger");
@@ -90,13 +101,13 @@ $(document).ready(function() {
         // update value of ckeditor instances
         let ckeditorInstance = element.find('textarea.customckeditor').attr("id");
         if(ckeditorInstance) CKEDITOR.instances[ckeditorInstance].updateElement(); 
-        const content = element.serialize();
+		const content = element.serialize();
         if(contentTest){
             if(contentTest(content) == false){
                 $.showNotification("Form validation failed", "danger", 15000);
                 return;
             }
-        }
+		}
         let request = $.ajax({
             type: method,
             url: url,
@@ -134,7 +145,7 @@ $(document).ready(function() {
             if(teamMembers != [] && $(".me").val() && !teamMembers.includes($(".me").val())){
                 location.reload();
             }
-        });
+		});
         return false;
     });
 

--- a/static/scripts/homework.js
+++ b/static/scripts/homework.js
@@ -5,7 +5,7 @@ import { softNavigate } from './helpers/navigation';
 const getDataValue = function(attr) {
     return function() {
         const value = $('.section-upload').data(attr);
-        return value ? value : undefined;
+		return value ? value : undefined;
     };
 };
 
@@ -101,7 +101,7 @@ $(document).ready(function() {
         const method  = element.attr("method");
         // update value of ckeditor instances
         let ckeditorInstance = element.find('textarea.customckeditor').attr("id");
-        if(ckeditorInstance) CKEDITOR.instances[ckeditorInstance].updateElement();
+		if(ckeditorInstance) CKEDITOR.instances[ckeditorInstance].updateElement();
 		const content = element.serialize();
         if(contentTest){
             if(contentTest(content) == false){
@@ -327,7 +327,7 @@ $(document).ready(function() {
 
                 if( parentId ) {
                     params.parent = parentId;
-                }
+				}
 
                 // post file meta to proxy file service for persisting data
                 $.post('/files/fileModel', params , (data) => {

--- a/static/scripts/homework.js
+++ b/static/scripts/homework.js
@@ -5,7 +5,7 @@ import { softNavigate } from './helpers/navigation';
 const getDataValue = function(attr) {
     return function() {
         const value = $('.section-upload').data(attr);
-		return value ? value : undefined;
+		return (value || undefined);
     };
 };
 
@@ -101,7 +101,7 @@ $(document).ready(function() {
         const method  = element.attr("method");
         // update value of ckeditor instances
         let ckeditorInstance = element.find('textarea.customckeditor').attr("id");
-		if(ckeditorInstance) CKEDITOR.instances[ckeditorInstance].updateElement();
+		if (ckeditorInstance) CKEDITOR.instances[ckeditorInstance].updateElement();
 		const content = element.serialize();
         if(contentTest){
             if(contentTest(content) == false){

--- a/static/scripts/homework.js
+++ b/static/scripts/homework.js
@@ -69,7 +69,7 @@ window.addEventListener("DOMContentLoaded", function(){
 });
 $(document).ready(function() {
 	CKEDITOR.instances.evaluation.on('change', () => {
-		const submitButton = document.getElementById('button-save-submission');
+		const submitButton = document.getElementsByClassName('js-submit-btn')[0];
 		const content = CKEDITOR.instances.evaluation.document.getBody().getText();
 		if (!content.trim()) {
 			submitButton.disabled = true;

--- a/static/scripts/homework.js
+++ b/static/scripts/homework.js
@@ -1,12 +1,11 @@
-﻿/* global CKEDITOR */
-/* eslint unicode-bom: "always" */
+/* global CKEDITOR */
 
 import { softNavigate } from './helpers/navigation';
 
 const getDataValue = function(attr) {
     return function() {
         const value = $('.section-upload').data(attr);
-        return value ? value : undefined;    
+        return value ? value : undefined;
     };
 };
 
@@ -102,7 +101,7 @@ $(document).ready(function() {
         const method  = element.attr("method");
         // update value of ckeditor instances
         let ckeditorInstance = element.find('textarea.customckeditor').attr("id");
-        if(ckeditorInstance) CKEDITOR.instances[ckeditorInstance].updateElement(); 
+        if(ckeditorInstance) CKEDITOR.instances[ckeditorInstance].updateElement();
 		const content = element.serialize();
         if(contentTest){
             if(contentTest(content) == false){
@@ -328,7 +327,7 @@ $(document).ready(function() {
 
                 if( parentId ) {
                     params.parent = parentId;
-                }              
+                }
 
                 // post file meta to proxy file service for persisting data
                 $.post('/files/fileModel', params , (data) => {

--- a/static/scripts/homework.js
+++ b/static/scripts/homework.js
@@ -1,4 +1,6 @@
-﻿import { softNavigate } from './helpers/navigation';
+﻿/* eslint-env CKEDITOR */
+
+import { softNavigate } from './helpers/navigation';
 
 const getDataValue = function(attr) {
     return function() {
@@ -66,13 +68,12 @@ window.addEventListener("DOMContentLoaded", function(){
     document.querySelector(".filter").dispatchEvent(new CustomEvent("getFilter"));
 });
 $(document).ready(function() {
-	CKEDITOR.instances.evaluation.on('change', () => { 
+	CKEDITOR.instances.evaluation.on('change', () => {
 		const submitButton = document.getElementById('button-save-submission');
-		let content = CKEDITOR.instances.evaluation.document.getBody().getText();
-		if(!content.trim()) {
+		const content = CKEDITOR.instances.evaluation.document.getBody().getText();
+		if (!content.trim()) {
 			submitButton.disabled = true;
-		}
-		else{
+		} else {
 			submitButton.disabled = false;
 		}
 	});

--- a/static/scripts/homework.js
+++ b/static/scripts/homework.js
@@ -1,5 +1,5 @@
 ﻿/* global CKEDITOR */
-/* eslint unicode-bom: "error" */
+/* eslint unicode-bom: "always" */
 
 import { softNavigate } from './helpers/navigation';
 

--- a/views/homework/submission.hbs
+++ b/views/homework/submission.hbs
@@ -81,7 +81,7 @@
 
     {{#if @root.submittable}}
         {{#userHasPermission "HOMEWORK_CREATE"}}
-            <button id="button-save-submission" type="submit" class="btn btn-primary btn-submit" disabled="true">Speichern</button>
+            <button type="submit" class="btn btn-primary btn-submit js-submit-btn" disabled="true">Speichern</button>
         {{/userHasPermission}}
 
         {{#if @root.submission}}

--- a/views/homework/submission.hbs
+++ b/views/homework/submission.hbs
@@ -81,7 +81,7 @@
 
     {{#if @root.submittable}}
         {{#userHasPermission "HOMEWORK_CREATE"}}
-            <button type="submit" class="btn btn-primary btn-submit">Speichern</button>
+            <button id="button-save-submission" type="submit" class="btn btn-primary btn-submit" disabled="true">Speichern</button>
         {{/userHasPermission}}
 
         {{#if @root.submission}}


### PR DESCRIPTION
[SC-1018](https://ticketsystem.schul-cloud.org/browse/SC-1018)

Umsetzung:

Wenn der Editor keinen Inhalt (außer Whitespaces) enthält, ist der "Speichern"-Button deaktiviert:

![SC-1018-reject-empty-submissions-1](https://user-images.githubusercontent.com/33292321/57128454-c4bf4400-6d93-11e9-87b3-02beb0f9b47d.png)

Sobald Inhalt eingegeben wurde, wird der "Speichern"-Button aktiviert:

![SC-1018-reject-empty-submissions-2](https://user-images.githubusercontent.com/33292321/57128452-c2f58080-6d93-11e9-976b-0291cc193352.png)

# Checkliste

- Bis die komplette Checkliste abgearbeitet ist muss das PR-Label WIP gesetzt sein

## Allgemein
- [x] Links zu verwandten PRs anderer Repositories
  - https://github.com/schul-cloud/schulcloud-server/pulls/????
  - Im Ticket (oder PR, wenn kein Ticket): Beschreibung und Begründung der Änderung/Neuerungen
- [x] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-????

## Code Qualität
- [x] Code mit Hinblick auf Security und Datensicherheit betrachten
- [x] Linter darf keine Probleme bei veränderten Dateien aufweisen
- [x] Kern-Logik ist hinter der API implementiert?

## UX
- [x] UI-Änderungen wurden von der UX-Gruppe akzeptiert

## Tests
- [x] Test-Coverage darf durch PR nicht sinken
- [x] Unit-Tests und Integrations-Tests schreiben / ändern
- [x] Keine offenen bekannten Bugs im entwickelten Code

## Deployable
- [x] Feature Toggle notwendig (z.B. Environment-Variablen)
- [x] Datenbankanpassungen notwendig / Migrationsskripte
  - Alle DB-Anpassungen müssen in den Seed-Daten reflektiert werden
- [x] Notwendige neue Konfiguration an der Infrastruktur wurde mit Dev-Ops besprochen

## Dokumentation
- [x] Neue Abhängigkeiten (Repos, NPM Pakete, Vendor Skripte) begründen und überprüfen (Stabilität, Performance, Aktualität, Autor)
  - Begründung:
- [x] Übergabe/Schulung & Administrationsinfos (#Busfaktor, Confluence intern)
- [x] Dokumentation (wenn notwendig)
  - Code
  - Confluence - https://docs.schul-cloud.org
  - Guidelines / Hilfe
  - Release Notes - wenn es sich um große Feature-Releases handelt
- [x] mind. 1 Screenshot bei Content-Änderungen

## Datenschutz
- [x] Neue Verarbeitung von personenbezogene Daten wurde mit der Datenschutz-Gruppe besprochen

## Freigabe zum Review
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)