### PR TITLE
SC-1244-teacher-and-substitution-of-course-should-be-different

### DIFF
--- a/controllers/courses.js
+++ b/controllers/courses.js
@@ -106,11 +106,11 @@ const editCourseHandler = (req, res, next) => {
         classesPromise,
         teachersPromise,
         studentsPromise
-    ]).then(([course, classes, teachers, students]) => {
+    ]).then(([course, _classes, _teachers, _students]) => {
         // these 3 might not change anything because hooks allow just ownSchool results by now, but to be sure:
-		classes = classes.filter(c => c.schoolId === res.locals.currentSchool);
-		teachers = teachers.filter(t => t.schoolId === res.locals.currentSchool);
-		students = students.filter(s => s.schoolId === res.locals.currentSchool);
+		const classes = _classes.filter(c => c.schoolId === res.locals.currentSchool);
+		const teachers = _teachers.filter(t => t.schoolId === res.locals.currentSchool);
+		const students = _students.filter(s => s.schoolId === res.locals.currentSchool);
 		const substitutions = _.cloneDeep(teachers.filter(t => t._id !== res.locals.currentUser._id));
 
         // map course times to fit into UI

--- a/controllers/courses.js
+++ b/controllers/courses.js
@@ -110,8 +110,8 @@ const editCourseHandler = (req, res, next) => {
         // these 3 might not change anything because hooks allow just ownSchool results by now, but to be sure:
         classes = classes.filter(c => c.schoolId == res.locals.currentSchool);
         teachers = teachers.filter(t => t.schoolId == res.locals.currentSchool);
-        students = students.filter(s => s.schoolId == res.locals.currentSchool);
-        let substitutions = _.cloneDeep(teachers);
+		students = students.filter(s => s.schoolId == res.locals.currentSchool);
+		const substitutions = _.cloneDeep(teachers.filter(t => t._id !== res.locals.currentUser._id));
 
         // map course times to fit into UI
         (course.times || []).forEach((time, count) => {

--- a/controllers/courses.js
+++ b/controllers/courses.js
@@ -106,7 +106,7 @@ const editCourseHandler = (req, res, next) => {
         classesPromise,
         teachersPromise,
         studentsPromise
-    ]).then(([course, _classes, _teachers, _students]) => {
+	]).then(([course, _classes, _teachers, _students]) => {
         // these 3 might not change anything because hooks allow just ownSchool results by now, but to be sure:
 		const classes = _classes.filter(c => c.schoolId === res.locals.currentSchool);
 		const teachers = _teachers.filter(t => t.schoolId === res.locals.currentSchool);

--- a/controllers/courses.js
+++ b/controllers/courses.js
@@ -108,9 +108,9 @@ const editCourseHandler = (req, res, next) => {
         studentsPromise
     ]).then(([course, classes, teachers, students]) => {
         // these 3 might not change anything because hooks allow just ownSchool results by now, but to be sure:
-        classes = classes.filter(c => c.schoolId == res.locals.currentSchool);
-        teachers = teachers.filter(t => t.schoolId == res.locals.currentSchool);
-		students = students.filter(s => s.schoolId == res.locals.currentSchool);
+		classes = classes.filter(c => c.schoolId === res.locals.currentSchool);
+		teachers = teachers.filter(t => t.schoolId === res.locals.currentSchool);
+		students = students.filter(s => s.schoolId === res.locals.currentSchool);
 		const substitutions = _.cloneDeep(teachers.filter(t => t._id !== res.locals.currentUser._id));
 
         // map course times to fit into UI


### PR DESCRIPTION
[SC-1244](https://ticketsystem.schul-cloud.org/browse/SC-1244)

Beim Menü zur Kurserstellung wird der aktuelle Nutzer nun aus der Liste der möglichen Vertretungslehrer herausgefiltert, sodass sich er sich nicht mehr als selbst als Vertretung hinzufügen kann:

![SC-1244-teacher-and-substitution-of-course-should-be-different](https://user-images.githubusercontent.com/33292321/57402049-cabf8580-71d6-11e9-9f8c-d69da3fd2981.png)


# Checkliste

- Bis die komplette Checkliste abgearbeitet ist muss das PR-Label WIP gesetzt sein

## Allgemein
- [x] Links zu verwandten PRs anderer Repositories
  - https://github.com/schul-cloud/schulcloud-server/pulls/????
  - Im Ticket (oder PR, wenn kein Ticket): Beschreibung und Begründung der Änderung/Neuerungen
- [x] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-????

## Code Qualität
- [x] Code mit Hinblick auf Security und Datensicherheit betrachten
- [x] Linter darf keine Probleme bei veränderten Dateien aufweisen
- [x] Kern-Logik ist hinter der API implementiert?

## UX
- [x] UI-Änderungen wurden von der UX-Gruppe akzeptiert

## Tests
- [x] Test-Coverage darf durch PR nicht sinken
- [x] Unit-Tests und Integrations-Tests schreiben / ändern
- [x] Keine offenen bekannten Bugs im entwickelten Code

## Deployable
- [x] Feature Toggle notwendig (z.B. Environment-Variablen)
- [x] Datenbankanpassungen notwendig?
  - Gibt es ein Migrationsskripte?
  - Alle DB-Anpassungen müssen in den Seed-Daten reflektiert werden
- [x] Notwendige neue Konfiguration an der Infrastruktur wurde mit Dev-Ops besprochen

## Dokumentation
- [x] Neue Abhängigkeiten (Repos, NPM Pakete, Vendor Skripte) begründen und überprüfen (Stabilität, Performance, Aktualität, Autor)
  - Begründung:
- [x] Übergabe/Schulung & Administrationsinfos (#Busfaktor, Confluence intern)
- [x] Dokumentation (wenn notwendig)
  - Code
  - Confluence - https://docs.schul-cloud.org
  - Guidelines / Hilfe
  - Release Notes - wenn es sich um große Feature-Releases handelt
- [x] mind. 1 Screenshot bei Content-Änderungen

## Datenschutz
- [x] Neue Verarbeitung von personenbezogene Daten wurde mit der Datenschutz-Gruppe besprochen

## Freigabe zum Review
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)