### PR TITLE
Hotfix/SC-1306 Fix too long firstlogin

### DIFF
--- a/controllers/registration.js
+++ b/controllers/registration.js
@@ -43,8 +43,6 @@ router.post(['/registration/submit', '/registration/submit/:sso/:accountId'], (r
 	}
 
 	// normalize form data
-	req.body.privacyConsent = (req.body.privacyConsent || req.body.parent_privacyConsent) === 'true';
-	req.body.termsOfUseConsent = (req.body.termsOfUseConsent || req.body.parent_termsOfUseConsent) === 'true';
 	req.body.roles = Array.isArray(req.body.roles) ? req.body.roles : [req.body.roles];
 
 	return api(req)

--- a/controllers/registration.js
+++ b/controllers/registration.js
@@ -43,8 +43,8 @@ router.post(['/registration/submit', '/registration/submit/:sso/:accountId'], (r
 	}
 
 	// normalize form data
-	req.body.privacyConsent = (req.body.privacyConsent||req.body.parent_privacyConsent) === 'true';
-	req.body.termsOfUseConsent = (req.body.termsOfUseConsent||req.body.parent_termsOfUseConsent) === 'true';
+	req.body.privacyConsent = (req.body.privacyConsent || req.body.parent_privacyConsent) === 'true';
+	req.body.termsOfUseConsent = (req.body.termsOfUseConsent || req.body.parent_termsOfUseConsent) === 'true';
 	req.body.roles = Array.isArray(req.body.roles) ? req.body.roles : [req.body.roles];
 
 	return api(req)

--- a/controllers/registration.js
+++ b/controllers/registration.js
@@ -43,8 +43,8 @@ router.post(['/registration/submit', '/registration/submit/:sso/:accountId'], (r
 	}
 
 	// normalize form data
-	req.body.privacyConsent = req.body.privacyConsent === 'true';
-	req.body.termsOfUseConsent = req.body.termsOfUseConsent === 'true';
+	req.body.privacyConsent = (req.body.privacyConsent||req.body.parent_privacyConsent) === 'true';
+	req.body.termsOfUseConsent = (req.body.termsOfUseConsent||req.body.parent_termsOfUseConsent) === 'true';
 	req.body.roles = Array.isArray(req.body.roles) ? req.body.roles : [req.body.roles];
 
 	return api(req)


### PR DESCRIPTION
# Checkliste
Formularfelder wurden beim Ausfüllen durch Eltern (Registration unter 16) nicht korrekt erkannt und der Consent mit falses abgespeichert. Dadurch wurde im Firstlogin nochmal nach Elternconsents gefragt.
Server-PR: https://github.com/schul-cloud/schulcloud-server/pull/602

## Allgemein
- [x] Links zu verwandten PRs anderer Repositories
  - https://github.com/schul-cloud/schulcloud-server/pull/602
  - Im Ticket (oder PR, wenn kein Ticket): Beschreibung und Begründung der Änderung/Neuerungen
- [x] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-1306

## Code Qualität
- [x] Code mit Hinblick auf Security und Datensicherheit betrachten
- [x] Linter darf keine Probleme bei veränderten Dateien aufweisen
- [x] Kern-Logik ist hinter der API implementiert?

## Freigabe zum Review
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde
