### PR TITLE
SC-1480 - Fix merging issue for SC-1341 and SC-1469 Administration Logic

### DIFF
--- a/views/administration/teams.hbs
+++ b/views/administration/teams.hbs
@@ -14,8 +14,12 @@
             <input type="hidden" name="_method" value="patch" />
             <div class="form-group" id="enableStudentsTeamsCreate">
                 <label>
-                    <input type="checkbox" name="disablestudentteamcreation" value="true" {{#inArray "disableStudentTeamCreation" school.features}}checked{{/inArray}}>
-                    Schülern verbieten, Teams anzulegen
+                    <input type="checkbox" name="enablestudentteamcreation" value="true"
+                    {{#inArray "disableStudentTeamCreation" school.features}}
+                    {{else}}
+                    checked
+                    {{/inArray}}>
+                    Schülern ist erlaubt Teams anzulegen
                     <p class="text-muted">Durch das Aktivieren dieser Option bestätigen Sie, dass Sie weisungsberechtigter Schul-Administrator sind und befugt sind,
                     das Anlegen von Teams durch Schüler an Ihrer Schule zu (de)aktiveren. Ihr Klick gilt insofern als Weisung der Schule gegenüber dem HPI.</p>
                 </label>


### PR DESCRIPTION
Change logic to set student creation on team in administration settings

# Checkliste

- Bis die komplette Checkliste abgearbeitet ist muss das PR-Label WIP gesetzt sein

## Allgemein
- [x] Links zu verwandten PRs anderer Repositories
  - https://github.com/schul-cloud/schulcloud-server/pulls/????
  - Im Ticket (oder PR, wenn kein Ticket): Beschreibung und Begründung der Änderung/Neuerungen
- [x] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-1480 / SC-1469

## Code Qualität
- [x] Code mit Hinblick auf Security und Datensicherheit betrachten
- [x] Linter darf keine Probleme bei veränderten Dateien aufweisen
- [x] Kern-Logik ist hinter der API implementiert?

## UX
- [x] UI-Änderungen wurden von der UX-Gruppe akzeptiert

## Tests
- [x] Test-Coverage darf durch PR nicht sinken
- [x] Unit-Tests und Integrations-Tests schreiben / ändern
- [x] Keine offenen bekannten Bugs im entwickelten Code

## Deployable
- [x] Feature Toggle notwendig (z.B. Environment-Variablen)
- [x] Datenbankanpassungen notwendig?
  - Gibt es ein Migrationsskripte?
  - Alle DB-Anpassungen müssen in den Seed-Daten reflektiert werden
- [x] Notwendige neue Konfiguration an der Infrastruktur wurde mit Dev-Ops besprochen

## Dokumentation
- [x] Neue Abhängigkeiten (Repos, NPM Pakete, Vendor Skripte) begründen und überprüfen (Stabilität, Performance, Aktualität, Autor)
  - Begründung:
- [x] Übergabe/Schulung & Administrationsinfos (#Busfaktor, Confluence intern)
- [x] Dokumentation (wenn notwendig)
  - Code
  - Confluence - https://docs.schul-cloud.org
  - Guidelines / Hilfe
  - Release Notes - wenn es sich um große Feature-Releases handelt
- [x] mind. 1 Screenshot bei Content-Änderungen

## Datenschutz
- [x] Neue Verarbeitung von personenbezogene Daten wurde mit der Datenschutz-Gruppe besprochen

## Freigabe zum Review
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
