### PR TITLE
SC-1327 team calendar permissions

### DIFF
--- a/controllers/teams.js
+++ b/controllers/teams.js
@@ -626,6 +626,7 @@ router.get('/:teamId', async (req, res, next) => {
 				canCreateDir: true,
 				canCreateFile: true,
 				canEditPermissions: permissions.includes('EDIT_ALL_FILES'),
+				canEditEvents: permissions.includes('NEWS_EDIT'),
 				createEventAction: `/teams/${req.params.teamId}/events/`,
 				leaveTeamAction,
 				couldLeave,

--- a/controllers/teams.js
+++ b/controllers/teams.js
@@ -601,6 +601,8 @@ router.get('/:teamId', async (req, res, next) => {
 		// teamowner could not leave if there is no other teamowner
 		const couldLeave = checkIfUserCouldLeaveTeam(course.user, course.userIds);
 
+		const permissions = await api(req).get(`/teams/${teamId}/userPermissions/${course.user.userId}`);
+
 		res.render(
 			'teams/team',
 			Object.assign({}, course, {
@@ -613,7 +615,7 @@ router.get('/:teamId', async (req, res, next) => {
 					},
 					{},
 				],
-				permissions: course.user.permissions,
+				permissions,
 				course,
 				events,
 				directories,
@@ -623,7 +625,7 @@ router.get('/:teamId', async (req, res, next) => {
 				canUploadFile: true,
 				canCreateDir: true,
 				canCreateFile: true,
-				canEditPermissions: course.user.permissions.includes('EDIT_ALL_FILES'),
+				canEditPermissions: permissions.includes('EDIT_ALL_FILES'),
 				createEventAction: `/teams/${req.params.teamId}/events/`,
 				leaveTeamAction,
 				couldLeave,

--- a/controllers/teams.js
+++ b/controllers/teams.js
@@ -625,7 +625,7 @@ router.get('/:teamId', async (req, res, next) => {
 				canCreateDir: true,
 				canCreateFile: true,
 				canEditPermissions: permissions.includes('EDIT_ALL_FILES'),
-				canEditEvents: permissions.includes('NEWS_EDIT'),
+				canEditEvents: permissions.includes('CALENDAR_EDIT'),
 				createEventAction: `/teams/${req.params.teamId}/events/`,
 				leaveTeamAction,
 				couldLeave,

--- a/controllers/teams.js
+++ b/controllers/teams.js
@@ -570,7 +570,6 @@ router.get('/:teamId', async (req, res, next) => {
 		});
 
 		let events = [];
-
 		try {
 			events = await api(req).get('/calendar/', {
 				qs: {
@@ -578,7 +577,6 @@ router.get('/:teamId', async (req, res, next) => {
 					all: true,
 				},
 			});
-
 			events = events.map((event) => {
 				const start = moment(event.start);
 				const end = moment(event.end);
@@ -592,6 +590,7 @@ router.get('/:teamId', async (req, res, next) => {
 				event.fromTo = `${start.format('HH:mm')} - ${end.format('HH:mm')}`;
 				return event;
 			});
+			events = events.sort((a, b) => a.start - b.start);
 		} catch (e) {
 			events = [];
 		}

--- a/static/scripts/calendar.js
+++ b/static/scripts/calendar.js
@@ -34,7 +34,7 @@ $(document).ready(function () {
             var courseId = event["x-sc-courseId"];
             $.getJSON("/courses/" + courseId + "/json", function (course) {
                 var $title = modal.find(".modal-title");
-                $title.html($title.html() + " , Kurs: " + course.course.name);
+                $title.html($title.html() + ", Kurs: " + course.course.name);
 
                 // if not teacher, not allow editing course events
                 if($('.create-course-event').length <= 0) {
@@ -51,7 +51,7 @@ $(document).ready(function () {
             var teamId = event["x-sc-teamId"];
             $.getJSON("/teams/" + teamId + "/json", function (team) {
                 var $title = modal.find(".modal-title");
-                $title.html($title.html() + " , Team: " + team.team.name);
+                $title.html($title.html() + ", Team: " + team.team.name);
 
                 // if not teacher, not allow editing team events
                 if($('.create-team-event').length <= 0) {

--- a/static/scripts/calendar.js
+++ b/static/scripts/calendar.js
@@ -111,19 +111,26 @@ $(document).ready(function () {
                     action: '/calendar/events/' + event.attributes.uid
                 });
 
-                transformCourseOrTeamEvent($editEventModal, event);
-
-                $editEventModal.find('.btn-delete').click(e => {
-                    $.ajax({
-                        url: '/calendar/events/' + event.attributes.uid,
-                        type: 'DELETE',
-                        error: showAJAXError,
-                        success: function(result) {
-                            reloadCalendar();
-                        },
+                if (event["x-sc-courseId"]) { // course event
+                    transformCourseOrTeamEvent($editEventModal, event);
+                    $editEventModal.find('.btn-delete').click(e => {
+                        $.ajax({
+                            url: '/calendar/events/' + event.attributes.uid,
+                            type: 'DELETE',
+                            error: showAJAXError,
+                            success: function(result) {
+                                reloadCalendar();
+                            },
+                        });
                     });
-                });
-                $editEventModal.appendTo('body').modal('show');
+                    $editEventModal.appendTo('body').modal('show');
+                }
+
+                if (event["x-sc-teamId"]) { // team event
+                    const teamId = event["x-sc-teamId"];
+                    window.location.assign(`/teams/${teamId}?activeTab=events`);
+                }
+
             }
         },
         dayClick: function(date, jsEvent, view) {

--- a/static/scripts/teams.js
+++ b/static/scripts/teams.js
@@ -5,46 +5,21 @@ import moment from 'moment';
 import 'jquery-datetimepicker';
 
 /**
- * transform a event modal-form for course events
+ * transform a event modal-form for team events
  * @param modal {DOM-Element} - the given modal which will be transformed
- * @param event {object} - a event, maybe a course-event
+ * @param event {object} - a team event
  */
-function transformCourseOrTeamEvent(modal, event) {
-	if (event['x-sc-courseId']) {
-		const courseId = event['x-sc-courseId'];
-		$.getJSON(`/courses/${courseId}/json`, (course) => {
-			const $title = modal.find('.modal-title');
-			$title.html(`${$title.html()} , Kurs: ${course.course.name}`);
-
-			// if not teacher, not allow editing course events
-			if ($('.create-course-event').length <= 0) {
-				modal.find('.modal-form :input').attr('disabled', true);
-			}
-
-			// set fix course on editing
-			modal.find("input[name='scopeId']").attr('value', event['x-sc-courseId']);
-			modal.find('.modal-form').append(`<input name='courseId' value='${courseId}' type='hidden'>`);
-			modal.find('.create-course-event').remove();
-			modal.find('.create-team-event').remove();
-		});
-	} else if (event['x-sc-teamId']) {
-		const teamId = event['x-sc-teamId'];
-		$.getJSON(`/teams/${teamId}/json`, (team) => {
-			const $title = modal.find('.modal-title');
-			$title.html(`${$title.html()} , Team: ${team.team.name}`);
-
-			// if not teacher, not allow editing team events
-			if ($('.create-team-event').length <= 0) {
-				modal.find('.modal-form :input').attr('disabled', true);
-			}
-
-			// set fix team on editing
-			modal.find("input[name='scopeId']").attr('value', event['x-sc-teamId']);
-			modal.find('.modal-form').append(`<input name='teamId' value='${teamId}' type='hidden'>`);
-			modal.find('.create-team-event').remove();
-			modal.find('.create-course-event').remove();
-		});
-	}
+function transformTeamEvent(modal, event) {
+	const teamId = event['x-sc-teamId'];
+	$.getJSON(`/teams/${teamId}/json`, (team) => {
+		const $title = modal.find('.modal-title');
+		$title.html(`${$title.html()} , Team: ${team.team.name}`);
+		// set fix team on editing
+		modal.find("input[name='scopeId']").attr('value', event['x-sc-teamId']);
+		modal.find('.modal-form').append(`<input name='teamId' value='${teamId}' type='hidden'>`);
+		modal.find('.create-team-event').remove();
+		modal.find('.create-course-event').remove();
+	});
 }
 
 $(document).ready(() => {
@@ -126,7 +101,6 @@ $(document).ready(() => {
 			window.location.href = event.url;
 			return false;
 		}
-		// personal event
 		event.startDate = event.start.format('DD.MM.YYYY HH:mm');
 		event.endDate = (event.end || event.start).format('DD.MM.YYYY HH:mm');
 		populateModalForm($editEventModal, {
@@ -137,7 +111,7 @@ $(document).ready(() => {
 			action: `/teams/calendar/events/${event.attributes.uid}`,
 		});
 
-		transformCourseOrTeamEvent($editEventModal, event);
+		transformTeamEvent($editEventModal, event);
 
 		$editEventModal.find('.btn-delete').click(() => {
 			$.ajax({

--- a/static/scripts/teams.js
+++ b/static/scripts/teams.js
@@ -13,7 +13,7 @@ function transformTeamEvent(modal, event) {
 	const teamId = event['x-sc-teamId'];
 	$.getJSON(`/teams/${teamId}/json`, (team) => {
 		const $title = modal.find('.modal-title');
-		$title.html(`${$title.html()} , Team: ${team.team.name}`);
+		$title.html(`${$title.html()}, Team: ${team.team.name}`);
 		// set fix team on editing
 		modal.find("input[name='scopeId']").attr('value', event['x-sc-teamId']);
 		modal.find('.modal-form').append(`<input name='teamId' value='${teamId}' type='hidden'>`);

--- a/views/calendar/calendar.hbs
+++ b/views/calendar/calendar.hbs
@@ -14,7 +14,7 @@
             <div class="fullcalendar" id="calendar"></div>
         </div>
 
-        {{#userHasPermission "CALENDAR_EVENT_CREATE"}}
+        {{#userHasPermission "CALENDAR_CREATE"}}
         {{#embed "lib/components/modal-form" class="create-event-modal" action="/calendar/events/" userId=../userId}}
             {{#content "fields"}}
                 {{> "calendar/forms/form-create-event" addCourse="true" addTeam="true" collapseIdCourse="2" collapseIdTeam="3"}}

--- a/views/calendar/card.hbs
+++ b/views/calendar/card.hbs
@@ -94,6 +94,8 @@ i.ml-auto {
       </span>
       <span class="card-description">{{event.description}}</span>
     </div>
+    {{#if canEdit}}
     <i style="cursor: pointer; font-size: 18px" class="ml-auto btn-edit-event fa fa-edit"></i>
+    {{/if}}
   </div>
 </div>

--- a/views/teams/team.hbs
+++ b/views/teams/team.hbs
@@ -196,7 +196,7 @@
                         <div class="section" data-section="js-events">
                             <div class="row">
                                 {{#each ../events}}
-                                    {{> 'calendar/card' event=this}}
+                                    {{> 'calendar/card' event=this canEdit=../canEditEvents}}
                                 {{/each}}
                             </div>
                             <div style="margin-top: .5rem">

--- a/views/teams/team.hbs
+++ b/views/teams/team.hbs
@@ -200,7 +200,7 @@
                                 {{/each}}
                             </div>
                             <div style="margin-top: .5rem">
-                                {{#inArray "NEWS_CREATE" permissions}}
+                                {{#inArray "CALENDAR_CREATE" permissions}}
                                     <button class="btn btn-add btn-primary btn-create-event pull-right">
                                         Termin anlegen
                                     </button>


### PR DESCRIPTION
Ticket: https://ticketsystem.schul-cloud.org/browse/SC-1327
Server-PR: https://github.com/schul-cloud/schulcloud-server/pull/661
Migrationen: siehe Server-PR

Mit diesen Änderungen werden Team-Event-Edits bzw. Deletes nur noch zugelassen, wenn entsprechende Team-Permissions vorhanden sind. Gleiches gilt (wie gehabt) für die Erstellung von Team-Events. Bisher sind das nur UI-Changes; ein größerer API-Rewrite steht noch aus (Folgeticket siehe Server-PR).