### PR TITLE
SC-811 Check new TEAM_INVITE_EXTERNAL permission

### DIFF
--- a/controllers/teams.js
+++ b/controllers/teams.js
@@ -1051,6 +1051,7 @@ router.get('/:teamId/members', async (req, res, next) => {
 				deleteInvitationAction: `${uri}/invitation`,
 				resendInvitationAction: `${uri}/invitation`,
 				permissions: team.user.permissions,
+				rolePermissions: res.locals.currentUser.permissions,
 				method,
 				head,
 				body,

--- a/views/teams/members.hbs
+++ b/views/teams/members.hbs
@@ -33,12 +33,14 @@
                     {{/inArray}}
 
                     {{#inArray "INVITE_EXPERTS" permissions}}
-                        <div class="col-sm-6">
-                            <p>Lade Lehrer anderer Schulen und Experten per E-Mail ein.</p>
-                            <button class="btn btn-primary btn-invite-external-member">
-                                Externe Teilnehmer einladen
-                            </button>
-                        </div>
+                        {{#inArray "TEAM_INVITE_EXTERNAL" ../rolePermissions}}
+                            <div class="col-sm-6">
+                                <p>Lade Lehrer anderer Schulen und Experten per E-Mail ein.</p>
+                                <button class="btn btn-primary btn-invite-external-member">
+                                    Externe Teilnehmer einladen
+                                </button>
+                            </div>
+                        {{/inArray}}
                     {{/inArray}}
                 </div>
             </div>
@@ -103,11 +105,13 @@
                 {{/content}}
             {{/embed}}            
 
-            {{#embed "lib/components/modal-form" action=inviteExternalMemberAction class="invite-external-member-modal"}}
-                {{#content "fields"}}
-                    {{> "teams/forms/form-invite-external-member" teamId=../_id roles=rolesExternal}}
-                {{/content}}
-            {{/embed}}
+            {{#inArray "TEAM_INVITE_EXTERNAL" rolePermissions }}
+                {{#embed "lib/components/modal-form" action=inviteExternalMemberAction class="invite-external-member-modal"}}
+                    {{#content "fields"}}
+                        {{> "teams/forms/form-invite-external-member" teamId=../_id roles=rolesExternal}}
+                    {{/content}}
+                {{/embed}}
+            {{/inArray}}
 
             {{#embed "lib/components/modal-form" action=deleteMemberAction class="delete-member-modal"}}
                 {{#content "fields"}}


### PR DESCRIPTION
Ticket: https://ticketsystem.schul-cloud.org/browse/SC-811
Server-PR: https://github.com/schul-cloud/schulcloud-server/pull/665

Überprüft die im Server-PR eingeführte Berechtigung beim Rendering der Team-Mitglieder-verwalten-Seite und entfernt den entsprechenden Button und das Modal.

Läuft auch ohne Server-PR, allerdings kann dann niemand mehr externe Mitglieder einladen :-)