### PR TITLE
Update webpack.config.js build cache bug

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ const devPlugins = [
 	}),
 ];
 
-if (process.env.NODE_ENV === 'production') {
+if (process.env.NODE_ENV !== 'production') {
 	plugins.push(...devPlugins);
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,50 +1,60 @@
-const webpack = require("webpack");
+const webpack = require('webpack');
 const RebuildChangedPlugin = require('rebuild-changed-entrypoints-webpack-plugin');
 
+const plugins = [
+	// By default, moment loads aaaall the locale files, which bloats the bundle size
+	// This plugin forces moment to only load the German locale
+	new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /de/),
+];
+
+const devPlugins = [
+	// Rebuild onlyl changed files
+	new RebuildChangedPlugin({
+		cacheDirectory: __dirname,
+	}),
+];
+
+if (process.env.NODE_ENV === 'production') {
+	plugins.push(...devPlugins);
+}
+
 module.exports = {
-    mode: 'production',
-    module: {
-        rules: [
-            // All files that end on .js or .jsx are transpilled by babel
-            {
-                test: /\.(js|jsx)$/,
-                exclude: /(node_modules)/,
-                loader: 'babel-loader',
-                query: {
-                    presets: [["es2015"]],
-                    plugins: ["transform-react-jsx"]
-                },
-            },
-            // moment needs to be globally exposed in order to work with fullcalendar
-            { test: require.resolve('moment'), loader: 'expose-loader?moment' }
-        ]
-    },
-    optimization: {
-        splitChunks: {
-            cacheGroups: {
-                // Bundle react & react-dom into separate vendor-react bundle
-                react: {
-                  test: /[\\/]node_modules[\\/](react\-dom|react)[\\/]/,
-                  name: 'vendor-react',
-                  chunks: 'all',
-                },
-            }
-        },
-    },
-    externals: {
-        "jquery": "jQuery",
-        "jquery-mousewheel": "jQuery",
-    },
-    output: {
-        path: '/',
-        filename: '[name].js'
-    },
-    plugins: [
-        new RebuildChangedPlugin({
-            cacheDirectory: __dirname,
-        }),
-        // By default, moment loads aaaall the locale files, which bloats the bundle size
-        // This plugin forces moment to only load the German locale
-        new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /de/),
-    ]
+	mode: 'production',
+	module: {
+		rules: [
+			// All files that end on .js or .jsx are transpilled by babel
+			{
+				test: /\.(js|jsx)$/,
+				exclude: /(node_modules)/,
+				loader: 'babel-loader',
+				query: {
+					presets: [['es2015']],
+					plugins: ['transform-react-jsx'],
+				},
+			},
+			// moment needs to be globally exposed in order to work with fullcalendar
+			{ test: require.resolve('moment'), loader: 'expose-loader?moment' },
+		],
+	},
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				// Bundle react & react-dom into separate vendor-react bundle
+				react: {
+					test: /[\\/]node_modules[\\/](react\-dom|react)[\\/]/,
+					name: 'vendor-react',
+					chunks: 'all',
+				},
+			},
+		},
+	},
+	externals: {
+		jquery: 'jQuery',
+		'jquery-mousewheel': 'jQuery',
+	},
+	output: {
+		path: '/',
+		filename: '[name].js',
+	},
+	plugins,
 };


### PR DESCRIPTION
# Checkliste

- Fixt einen Bug im Webpack Script Cache Plugin, wodurch beim deployment die scripts nicht gebuilded wurden. Das Problem tritt vereinzelt auf, wenn es noch keinen cache (gulp und plugin cachefiles) und build ordner gibt. Im Plugin sekbst konnte ich keinen offensichtlichen Bug finden, aber das Plugin zu deaktiveren hat lokal bei mir geholfen. In Production benötigen wir sowieso kein caching.

## Freigabe zum Review
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
