### PR TITLE
Feature/automerge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,32 @@
+pull_request_rules:
+  - name: auto merge when label is set
+    conditions:
+      - label!=WIP
+      - label!=waiting
+      - label=ready to merge
+      - status-success~=Travis CI
+      - status-success~=Codacy
+      - status-success~=pullapprove
+    actions:
+      merge:
+        method: merge
+        strict: true
+  - name: remove ready to merge label when merged
+    conditions:
+      - merged
+      - label=ready to merge
+    actions:
+      label:
+        remove:
+          - ready to merge
+  - name: remove "ready to merge" label when pull is not approved
+    conditions:
+      - "#approved-reviews-by=0"
+      - label~=ready to merge
+      - -merged
+    actions:
+      comment:
+        message: The "ready to merge" label can only be set after one pull request approval
+      label:
+        remove:
+          - ready to merge

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,7 +21,7 @@ pull_request_rules:
           - ready to merge
   - name: remove "ready to merge" label when pull is not approved
     conditions:
-      - "#approved-reviews-by=0"
+      - status-failure~=pullapprove
       - label~=ready to merge
       - -merged
     actions:


### PR DESCRIPTION
Damit Pulls nicht so lange rumliegen.
Funktioniert bereits seit einigen Monaten super im nuxt-client

**Features:**
- alle pulls mit dem label "ready to merge" werden automatisch von diesem Bot gemerged, wenn alle Statuschecks grün sind. Sollte der Branch nicht mehr aktuell sein wird der branch automatisch vom head branch aktualisiert.
- Wenn das merge label gesetzt wird bevor alle statuschecks grün sind wird es automatisch wieder entfernt.
- Nach dem merge entfernt der Bot das label wieder, damit die übersichtsseite mit pulls nicht so überfüllt wird.

**Einrichtung:**
- https://github.com/marketplace/mergify für dieses Repo freischalten
- Diesen Pull mergen