### PR TITLE
Feature/sc 2119 teacher visibility in n21

### DIFF
--- a/controllers/account.js
+++ b/controllers/account.js
@@ -47,7 +47,7 @@ router.post('/', (req, res) => {
 router.get('/', (req, res, next) => {
 	const isSSO = Boolean(res.locals.currentPayload.systemId);
 	const isDiscoverable = res.locals.currentUser.discoverable;
-	const hideVisibilitySettings = (res.locals.currentRole === 'Schüler' || res.locals.theme.name === 'n21');
+	const hideVisibilitySettings = (res.locals.currentRole === 'Schüler' || process.env.IGNORE_DISCOVERABILITY);
 	Promise.all([
 		api(req).get(`/oauth2/auth/sessions/consent/${res.locals.currentUser._id}`),
 		(process.env.NOTIFICATION_SERVICE_ENABLED ? api(req).get('/notification/devices') : null),

--- a/controllers/account.js
+++ b/controllers/account.js
@@ -47,6 +47,7 @@ router.post('/', (req, res) => {
 router.get('/', (req, res, next) => {
 	const isSSO = Boolean(res.locals.currentPayload.systemId);
 	const isDiscoverable = res.locals.currentUser.discoverable;
+	const hideVisibilitySettings = (res.locals.currentRole === 'Schüler' || res.locals.theme.name === 'n21');
 	Promise.all([
 		api(req).get(`/oauth2/auth/sessions/consent/${res.locals.currentUser._id}`),
 		(process.env.NOTIFICATION_SERVICE_ENABLED ? api(req).get('/notification/devices') : null),
@@ -66,6 +67,7 @@ router.get('/', (req, res, next) => {
 			session,
 			userId: res.locals.currentUser._id,
 			sso: isSSO,
+			hideVisibilitySettings,
 			isDiscoverable,
 		});
 	}).catch(() => {
@@ -73,6 +75,7 @@ router.get('/', (req, res, next) => {
 			title: 'Dein Account',
 			userId: res.locals.currentUser._id,
 			sso: isSSO,
+			hideVisibilitySettings,
 			isDiscoverable,
 		});
 	});

--- a/views/account/settings.hbs
+++ b/views/account/settings.hbs
@@ -55,7 +55,7 @@
                 </div>
                 {{/userHasPermission}}
 
-				{{#unless (userHasRole "student")}}
+				{{#unless hideVisibilitySettings}}
 				<div class="form-group">
 					<label>
 						<input type="checkbox" name="discoverable" value="true" {{#if isDiscoverable}}checked{{/if}}>


### PR DESCRIPTION
# Checkliste

- Bis die komplette Checkliste abgearbeitet ist muss das PR-Label WIP gesetzt sein

## Allgemein
- [x] Links zu verwandten PRs anderer Repositories
  - Im Ticket (oder PR, wenn kein Ticket): Beschreibung und Begründung der Änderung/Neuerungen
- [x] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-2119

## Code Qualität
- [x] Code mit Hinblick auf Security und Datensicherheit betrachten
- [x] Linter darf keine Probleme bei veränderten Dateien aufweisen
- [x] Kern-Logik ist hinter der API implementiert?

## UX
- [x] UI-Änderungen wurden von der UX-Gruppe akzeptiert

## Tests
- [x] Test-Coverage darf durch PR nicht sinken
- [x] Unit-Tests und Integrations-Tests schreiben / ändern
- [x] Keine offenen bekannten Bugs im entwickelten Code

## Deployable
- [x] Feature Toggle notwendig (z.B. Environment-Variablen)
- [x] Datenbankanpassungen notwendig?
  - Gibt es ein Migrationsskripte?
  - Alle DB-Anpassungen müssen in den Seed-Daten reflektiert werden
- [x] Notwendige neue Konfiguration an der Infrastruktur wurde mit Dev-Ops besprochen

## Dokumentation
- [x] Neue Abhängigkeiten (Repos, NPM Pakete, Vendor Skripte) begründen und überprüfen (Stabilität, Performance, Aktualität, Autor)
  - Begründung:
- [x] Übergabe/Schulung & Administrationsinfos (#Busfaktor, Confluence intern)
- [x] Dokumentation (wenn notwendig)
  - Code
  - Confluence - https://docs.schul-cloud.org
  - Guidelines / Hilfe
  - Release Notes - wenn es sich um große Feature-Releases handelt
- [x] mind. 1 Screenshot bei Content-Änderungen

## Datenschutz
- [x] Neue Verarbeitung von personenbezogene Daten wurde mit der Datenschutz-Gruppe besprochen

## Freigabe zum Review
- [x] Die Änderungen wurden mit dem Ticket-Ersteller, Support-Team oder PO besprochen und erfüllen die Ticket-Anforderungen
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
