### PR TITLE
Don't break if class has no year set

### DIFF
--- a/controllers/administration.js
+++ b/controllers/administration.js
@@ -2214,7 +2214,7 @@ router.all(
 								title: 'Klasse löschen',
 							},
 						];
-						if (lastDefinedSchoolYear !== i.year._id
+						if (lastDefinedSchoolYear !== (i.year || {})._id
 							&& permissionsHelper.userHasPermission(res.locals.currentUser, 'USERGROUP_EDIT')
 						) {
 							baseActions.push({


### PR DESCRIPTION
Fix a bug that resulted in a 504 if there are classes without a year