### PR TITLE
integrate the nuxt client into the integration-test workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
       name: Integration
       env:
         - IT_CLIENT_HOST=nuxtclient
-        - IT_CLIENT_PORT=3200
+        - IT_CLIENT_PORT=4000
       git:
         clone: false
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,36 @@ env:
 
 jobs:
   include:
-    - stage: test
+    - stage: Test
       name: Mocha
+      before_install:
+        # move client into subdirectory
+        - mkdir -p schulcloud-client
+        - mv !(schulcloud-client) schulcloud-client
+        # fetch switch_branch script
+        - curl https://gist.github.com/schul-cloud-bot/a849c38804174f99ca7818782bf03c00/raw/switch_branch.sh > switch_branch.sh
+        - chmod 700 switch_branch.sh
+        # clone other required repositories and try to switch to branch with same name as current one
+        - git clone https://github.com/schul-cloud/schulcloud-server.git schulcloud-server
+        - sh switch_branch.sh "schulcloud-server" "$BRANCH_NAME"
+        - git clone https://github.com/schul-cloud/docker-compose.git docker-compose
+        - sh switch_branch.sh "docker-compose" "$BRANCH_NAME"
+      install:
+        # boot server
+        - cd docker-compose
+        - docker-compose -f docker-compose.integration-test-Build.yml up -d server
+        - cd ..
+        # client packages are needed for mocha
+        - cd schulcloud-client && npm ci && cd ..
+      before_script:
+        # seed database
+        - cd schulcloud-server && npm run setup && npm run seed && cd ..
       script: npm run mocha
     - script:
         - curl https://gist.githubusercontent.com/schul-cloud-bot/a849c38804174f99ca7818782bf03c00/raw/index.sh > integration-test.sh
         - chmod 700 integration-test.sh
         - sh integration-test.sh
-      name: "Integration"
+      name: Integration
       env:
         - IT_CLIENT_HOST=nuxtclient
         - IT_CLIENT_PORT=3200
@@ -34,8 +56,8 @@ jobs:
         clone: false
       install:
         - echo "skipping install"
-    - stage: deploy
-      name: deploy
+    - stage: Deploy
+      name: All Instances
       before_install:
         - openssl aes-256-cbc -K $encrypted_839866e404c6_key -iv $encrypted_839866e404c6_iv -in travis_rsa.enc -out travis_rsa -d
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,6 @@ jobs:
       env:
         - IT_CLIENT_HOST=nuxtclient
         - IT_CLIENT_PORT=4000
-      git:
-        clone: false
       install:
         - echo "skipping install"
     - stage: Deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,50 +17,31 @@ env:
     - FEATURE_TEAMS_ENABLED=true
     - IT_CLIENT_HOST=client
     - BRANCH_NAME=${TRAVIS_PULL_REQUEST_BRANCH:=$TRAVIS_BRANCH}
-before_install:
-  - openssl aes-256-cbc -K $encrypted_839866e404c6_key -iv $encrypted_839866e404c6_iv -in travis_rsa.enc -out travis_rsa -d
-  - echo $BRANCH_NAME
-  # move client into subdirectory
-  - mkdir -p schulcloud-client
-  - mv !(schulcloud-client) schulcloud-client
-  # fetch switch_branch script
-  - curl https://gist.githubusercontent.com/schul-cloud-bot/26e57e99fdae76f30927089c9dd99df7/raw/a590139da5f969a6d330f38ab2d85d3769c86f3f/switch_branch.sh > switch_branch.sh
-  - chmod 700 switch_branch.sh
-  # clone other required repositories and try to switch to branch with same name as current one
-  - git clone https://github.com/schul-cloud/schulcloud-server.git schulcloud-server
-  - sh switch_branch.sh "schulcloud-server" "$BRANCH_NAME"
-  - git clone https://github.com/schul-cloud/docker-compose.git docker-compose
-  - sh switch_branch.sh "docker-compose" "$BRANCH_NAME"
-  - git clone https://github.com/schul-cloud/integration-tests.git integration-tests
-  - sh switch_branch.sh "integration-tests" "$BRANCH_NAME"
-install:
-  # boot servers for integration tests
-  - cd docker-compose
-  - docker-compose -f docker-compose.integration-test-Build.yml build
-  - docker-compose -f docker-compose.integration-test-Build.yml up -d
-  - cd ..
-  # client packages are needed for mocha
-  - cd schulcloud-client && npm ci && cd ..
-  - cd integration-tests && npm ci && cd ..
-before_script:
-  - echo $TRAVIS_BRANCH
-  - echo $TRAVIS_TAG
-  # seed database
-  - cd schulcloud-server && npm run setup && npm run seed && cd ..
-script:
-  # all cd .. in seperate lines to go dir up on test fails
-  - cd schulcloud-client && npm run mocha
-  - cd ..
-  - cd integration-tests && npm run test
-  - cd ..
-after_script:
-  - npm i -g @adrianjost/report-viewer
-  - rv-upload -F **/reports/**/*.html
+
+jobs:
+  include:
+    - stage: test
+      name: Mocha
+      script: npm run mocha
+    - script:
+        - curl https://gist.githubusercontent.com/schul-cloud-bot/a849c38804174f99ca7818782bf03c00/raw/index.sh > integration-test.sh
+        - chmod 700 integration-test.sh
+        - sh integration-test.sh
+      name: "Integration"
+      git:
+        clone: false
+      install:
+        - echo "skipping install"
+    - stage: deploy
+      name: deploy
+      before_install:
+        - openssl aes-256-cbc -K $encrypted_839866e404c6_key -iv $encrypted_839866e404c6_iv -in travis_rsa.enc -out travis_rsa -d
+      before_script:
+        - echo $TRAVIS_BRANCH
+        - echo $TRAVIS_TAG
+      script:
+        - bash ./schulcloud-client/deploy.sh
+
 cache:
   directories:
     - "$HOME/.npm" # cache all packages installed with "npm ci"
-deploy:
-  provider: script
-  script: bash ./deploy.sh
-  on:
-    all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ env:
     - FEATURE_TEAMS_ENABLED=true
     - BRANCH_NAME=${TRAVIS_PULL_REQUEST_BRANCH:=$TRAVIS_BRANCH}
 stages:
-  - test
-  - deploy
+  - Test
+  - Deploy
 jobs:
   include:
-    - stage: test
-      name: mocha
+    - stage: Test
+      name: Mocha
       before_install:
         # move client into subdirectory
         - mkdir -p schulcloud-client
@@ -51,7 +51,7 @@ jobs:
         - curl https://gist.githubusercontent.com/schul-cloud-bot/a849c38804174f99ca7818782bf03c00/raw/index.sh > integration-test.sh
         - chmod 700 integration-test.sh
         - sh integration-test.sh
-      name: integration
+      name: Integration
       env:
         - IT_CLIENT_HOST=nuxtclient
         - IT_CLIENT_PORT=3200
@@ -59,7 +59,7 @@ jobs:
         clone: false
       install:
         - echo "skipping install"
-    - stage: deploy
+    - stage: Deploy
       name: All Instances
       before_install:
         - openssl aes-256-cbc -K $encrypted_839866e404c6_key -iv $encrypted_839866e404c6_iv -in travis_rsa.enc -out travis_rsa -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ jobs:
         - chmod 700 switch_branch.sh
         # clone other required repositories and try to switch to branch with same name as current one
         - git clone https://github.com/schul-cloud/schulcloud-server.git schulcloud-server
-        - sh switch_branch.sh "schulcloud-server" "$BRANCH_NAME"
+        - bash switch_branch.sh "schulcloud-server" "$BRANCH_NAME"
         - git clone https://github.com/schul-cloud/docker-compose.git docker-compose
-        - sh switch_branch.sh "docker-compose" "$BRANCH_NAME"
+        - bash switch_branch.sh "docker-compose" "$BRANCH_NAME"
       install:
         # boot server
         - cd docker-compose
@@ -50,7 +50,7 @@ jobs:
     - script:
         - curl https://gist.githubusercontent.com/schul-cloud-bot/a849c38804174f99ca7818782bf03c00/raw/index.sh > integration-test.sh
         - chmod 700 integration-test.sh
-        - sh integration-test.sh
+        - bash integration-test.sh
       name: Integration
       env:
         - IT_CLIENT_HOST=nuxtclient

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,13 @@ env:
     - PUBLIC_BACKEND_URL=http://localhost:3030
     - FEATURE_TEAMS_ENABLED=true
     - BRANCH_NAME=${TRAVIS_PULL_REQUEST_BRANCH:=$TRAVIS_BRANCH}
-
+stages:
+  - test
+  - deploy
 jobs:
   include:
-    - stage: Test
-      name: Mocha
+    - stage: test
+      name: mocha
       before_install:
         # move client into subdirectory
         - mkdir -p schulcloud-client
@@ -49,7 +51,7 @@ jobs:
         - curl https://gist.githubusercontent.com/schul-cloud-bot/a849c38804174f99ca7818782bf03c00/raw/index.sh > integration-test.sh
         - chmod 700 integration-test.sh
         - sh integration-test.sh
-      name: Integration
+      name: integration
       env:
         - IT_CLIENT_HOST=nuxtclient
         - IT_CLIENT_PORT=3200
@@ -57,7 +59,7 @@ jobs:
         clone: false
       install:
         - echo "skipping install"
-    - stage: Deploy
+    - stage: deploy
       name: All Instances
       before_install:
         - openssl aes-256-cbc -K $encrypted_839866e404c6_key -iv $encrypted_839866e404c6_iv -in travis_rsa.enc -out travis_rsa -d
@@ -65,7 +67,7 @@ jobs:
         - echo $TRAVIS_BRANCH
         - echo $TRAVIS_TAG
       script:
-        - bash ./schulcloud-client/deploy.sh
+        - bash ./deploy.sh
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js: '10'
-sudo: required
 branches:
   only:
     - develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ jobs:
       install:
         # boot server
         - cd docker-compose
+        - docker-compose -f docker-compose.integration-test-Build.yml build server
         - docker-compose -f docker-compose.integration-test-Build.yml up -d server
         - cd ..
         # client packages are needed for mocha
@@ -43,7 +44,7 @@ jobs:
       before_script:
         # seed database
         - cd schulcloud-server && npm run setup && npm run seed && cd ..
-      script: npm run mocha
+      script: cd schulcloud-client && npm run mocha && cd ..
     - script:
         - curl https://gist.githubusercontent.com/schul-cloud-bot/a849c38804174f99ca7818782bf03c00/raw/index.sh > integration-test.sh
         - chmod 700 integration-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
     - BACKEND_URL=http://localhost:3030
     - PUBLIC_BACKEND_URL=http://localhost:3030
     - FEATURE_TEAMS_ENABLED=true
-    - IT_CLIENT_HOST=client
     - BRANCH_NAME=${TRAVIS_PULL_REQUEST_BRANCH:=$TRAVIS_BRANCH}
 
 jobs:
@@ -28,6 +27,9 @@ jobs:
         - chmod 700 integration-test.sh
         - sh integration-test.sh
       name: "Integration"
+      env:
+        - IT_CLIENT_HOST=nuxtclient
+        - IT_CLIENT_PORT=3200
       git:
         clone: false
       install:


### PR DESCRIPTION
## Description

- simplify travis.yml by using jobs and moving the integration-test setup [into a gist](https://gist.github.com/schul-cloud-bot/a849c38804174f99ca7818782bf03c00).
- add nuxt to the integration test setup

```bash
curl https://gist.githubusercontent.com/schul-cloud-bot/a849c38804174f99ca7818782bf03c00/raw/index.sh > integration-test.sh
chmod 700 integration-test.sh
bash integration-test.sh
```

related pulls:
- required to be merged at the same time
  - https://github.com/schul-cloud/docker-compose/pull/5
  - https://github.com/schul-cloud/nuxt-client/pull/314
- optional, can also be merged later
  - https://github.com/schul-cloud/schulcloud-client/pull/1457
  - https://github.com/schul-cloud/integration-tests/pull/31