### PR TITLE
SC-1253 SC-2064 fix homework create handling

### DIFF
--- a/controllers/homework.js
+++ b/controllers/homework.js
@@ -127,7 +127,20 @@ const getCreateHandler = (service) => {
                 addFilePermissionsForTeamMembers(req, data.teamMembers, data.courseGroupId, data.fileIds) :
                 Promise.resolve({});
             return promise.then(_ => {
-                res.redirect(`${referrer}${data._id}`);
+				if (service === 'homework') {
+					if (req.body.courseId) {
+						// homework was created from inside a course with course reference
+						referrer = `/courses/${data.courseId}?activeTab=homeworks`;
+					} else if (!req.body.courseId && referrer.includes('/courses')) {
+						// homework is created inside a course but course reference was unset before create ("Kurs = Keine Zuordnung")
+						referrer = `${(req.headers.origin || process.env.HOST)}/homework/${data._id}`;
+					} else {
+						// homework was created from homeworks overview
+						referrer += data._id;
+					}
+				}
+				// includes submission was done
+                res.redirect(referrer);
             });
         }).catch(err => {
             next(err);


### PR DESCRIPTION
# Checkliste
fixes different behaviour with homeworks:
- homework created inside a course for a course
- homework created inside a course without course reference
- homework created from homeworks overview
- homework submission contains just a file not text

https://ticketsystem.schul-cloud.org/browse/SC-1253
https://ticketsystem.schul-cloud.org/browse/SC-2064

## Freigabe zum Review
- [x] Die Änderungen wurden mit dem Ticket-Ersteller, Support-Team oder PO besprochen und erfüllen die Ticket-Anforderungen
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
