### PR TITLE
SC-2622 - use window.scrollTo instead of Element.scrollTo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3000,6 +3000,12 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "browser-sync": {
       "version": "2.26.7",
       "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.7.tgz",
@@ -11544,6 +11550,7 @@
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
         "debug": "3.2.6",
         "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",

--- a/static/scripts/dataprivacy/paginated_form.js
+++ b/static/scripts/dataprivacy/paginated_form.js
@@ -1,7 +1,6 @@
 // set this to false to disable validation between pages (for testing)
 const ValidationDisabled = false;
 
-
 function CustomEventPolyfill() {
 	if (typeof window.CustomEvent === 'function') return false;
 	function CustomEvent(event, orgParams) {
@@ -28,12 +27,6 @@ if (!NodeList.prototype.some) {
 	NodeList.prototype.some = Array.prototype.some;
 }
 
-// Polyfill for IE
-if (!Element.prototype.scrollTo) {
-	// eslint-disable-next-line no-console
-	Element.prototype.scrollTo = () => { console.warn('your browser does not support .scrollTo()'); };
-}
-
 /* MULTIPAGE INPUT FORM */
 
 function getMaxSelectionIndex() {
@@ -45,7 +38,7 @@ function getSelectionIndex() {
 }
 function showInvalid(sectionNr) {
 	document.querySelector(`section[data-panel="section-${sectionNr}"]`).classList.add('show-invalid');
-	document.querySelector('.content-wrapper').scrollTo(0, 0);
+	window.scrollTo(0, 0);
 }
 function getSubmitPageIndex() {
 	const sections = document.querySelectorAll('form .panels section');
@@ -83,7 +76,7 @@ function updateButton(selectedIndex) {
 		document.querySelector('.form #prevSection').removeAttribute('disabled');
 	}
 
-	document.querySelector('.content-wrapper').scrollTo(0, 0);
+	window.scrollTo(0, 0);
 }
 
 function isSectionValid(sectionIndex) {


### PR DESCRIPTION
The UX is also getting improved by this, because the Element.scrollTo is kind of broken because of out fixed positioned topbar that lays above everything.
With window.scrollTo this is not relevant anymore.

# Checkliste

- Bis die komplette Checkliste abgearbeitet ist muss das PR-Label WIP gesetzt sein

## Allgemein
- [x] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-2622

## Code 
## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
