### PR TITLE
add option to skip test stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,11 @@ env:
     - FEATURE_TEAMS_ENABLED=true
     - BRANCH_NAME=${TRAVIS_PULL_REQUEST_BRANCH:=$TRAVIS_BRANCH}
 stages:
-  - Test
-  - Deploy
+  - name: Test
+    if: NOT (commit_message =~ /(skip-test-stage)/ AND branch = master)
+  - name: Deploy
+    if: NOT (commit_message =~ /(skip-deploy-stage)/)
+
 jobs:
   include:
     - stage: Test


### PR DESCRIPTION
# Checkliste

- added an option to skip the test stage for really urgant changes that need to be deployed fast. Just add **`skip-test-stage`** to your commit message
- only works if the pull targets the master branch
- it's not possible to change the order of the stages using this approach, because I am only allowed to define each stage name once (line 19-22). So in order to execute the tests afterwards you need another commit (where you add **`skip-deploy-stage`** to the commit message )

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
