### PR TITLE
SC-2780 - disable autocomplete on login form

### DIFF
--- a/views/authentication/forms/login.hbs
+++ b/views/authentication/forms/login.hbs
@@ -8,7 +8,7 @@
                 <input type="hidden" name="challenge" value={{challenge}} />
 
                 <div class="form-group">
-                    <input type="text" autocomplete="username" name="username" class="form-control form-control-lg" placeholder="E-Mail / Nutzername" data-testid="username" required>
+                    <input type="text" autocomplete="off" name="username" class="form-control form-control-lg" placeholder="E-Mail / Nutzername" data-testid="username" required>
                     <div class="input-group mt-1" id="show_hide_password">
                         <input type="password" autocomplete="current-password" name="password" class="form-control form-control-lg" placeholder="Passwort" data-testid="password" required>
                         <div class="input-group-addon">


### PR DESCRIPTION
# Checkliste

- save password still works, so you don't loose any comfort
- the username/email does not get suggested on shared devices (on all devices)

## Allgemein

- [x] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-2780 

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
