### PR TITLE
SC-2854 quick hotfix n21 help page contact form

### DIFF
--- a/theme/n21/views/help/help.hbs
+++ b/theme/n21/views/help/help.hbs
@@ -1,0 +1,27 @@
+{{#extend "lib/loggedin"}}
+
+    {{#content "styles" mode="append"}}
+        <link rel="stylesheet" href="/styles/help/help.css"/>
+    {{/content}}
+
+    {{#content "scripts" mode="append"}}
+        <script src="/scripts/help.js" type="text/javascript" defer></script>
+    {{/content}}
+
+    {{#content "page"}}
+
+        {{> "help/search" class="md-2"}}
+
+        <div class="container">
+            <div class="row">
+                {{#embed "help/partials/help_contact"}}{{/embed}}
+                
+                {{#embed "help/icon-card" title="Sprachlicher Hinweis" icon="fa-magic" class="" id="sprachhinweis"}}
+                    {{#content "card-body"}}
+                        {{> "help/language-hint"}}
+                    {{/content}}
+                {{/embed}}
+            </div>
+        </div>
+    {{/content}}
+{{/extend}}


### PR DESCRIPTION
# Checkliste
Help page now only contains a confluence search bar and contact form, nothing more. Confluence page is still the official N21 help page.

Ticket: https://ticketsystem.schul-cloud.org/browse/SC-2854

## UX
- [x] UI-Änderungen wurden von der UX-Gruppe akzeptiert
- [x] mind. 1 Screenshot bei Content-Änderungen:
![image](https://user-images.githubusercontent.com/6624503/70132225-13172700-1684-11ea-975a-33f8eeee8bf2.png)

## Freigabe zum Review
- [x] Die Änderungen wurden mit dem Ticket-Ersteller, Support-Team oder PO besprochen und erfüllen die Ticket-Anforderungen
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
