### PR TITLE
remove nodemon from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /home/node/app
 
 COPY ./package.json .
 COPY ./package-lock.json .
-RUN npm install -g nodemon gulp-cli && npm ci
+RUN npm install -g gulp-cli && npm ci
 
 COPY . .
 #COPY ./localtime /etc/localtime

--- a/Dockerfile.brb
+++ b/Dockerfile.brb
@@ -9,7 +9,7 @@ WORKDIR /home/node/app
 
 COPY ./package.json .
 COPY ./package-lock.json .
-RUN npm install -g nodemon gulp-cli && npm ci
+RUN npm install -g gulp-cli && npm ci
 
 COPY . .
 #COPY ./localtime /etc/localtime

--- a/Dockerfile.n21
+++ b/Dockerfile.n21
@@ -9,7 +9,7 @@ WORKDIR /home/node/app
 
 COPY ./package.json .
 COPY ./package-lock.json .
-RUN npm install -g nodemon gulp-cli && npm ci
+RUN npm install -g gulp-cli && npm ci
 
 COPY . .
 #COPY ./localtime /etc/localtime

--- a/Dockerfile.open
+++ b/Dockerfile.open
@@ -9,7 +9,7 @@ WORKDIR /home/node/app
 
 COPY ./package.json .
 COPY ./package-lock.json .
-RUN npm install -g nodemon gulp-cli && npm ci
+RUN npm install -g gulp-cli && npm ci
 
 COPY . .
 #COPY ./localtime /etc/localtime

--- a/Dockerfile.thr
+++ b/Dockerfile.thr
@@ -9,7 +9,7 @@ WORKDIR /home/node/app
 
 COPY ./package.json .
 COPY ./package-lock.json .
-RUN npm install -g nodemon gulp-cli && npm ci
+RUN npm install -g gulp-cli && npm ci
 
 COPY . .
 #COPY ./localtime /etc/localtime


### PR DESCRIPTION
nodemon is not used in production, so there is no need for it. It may be the reason why the build is failing from time to time

https://github.com/npm/uid-number/issues/3
https://github.com/npm/npm/issues/20861
https://jira.atlassian.com/browse/BCLOUD-16334
