### PR TITLE
use csrf token only in LTI1.3

### DIFF
--- a/controllers/tools.js
+++ b/controllers/tools.js
@@ -91,6 +91,7 @@ const runToolHandler = (req, res, next) => {
 		res.render('courses/components/run-lti-frame', {
 			url: tool.url,
 			method: 'POST',
+			csrf: (formData.lti_version === '1.3.0'),
 			formData: Object.keys(formData).map(key => ({ name: key, value: formData[key] })),
 		});
 	});

--- a/views/courses/components/run-lti-frame.hbs
+++ b/views/courses/components/run-lti-frame.hbs
@@ -8,5 +8,7 @@
     {{#each formData}}
         <input name="{{this.name}}" value="{{this.value}}">
     {{/each}}
-    {{> "lib/components/csrfInput"}}
+	{{#if csrf}}
+		{{> "lib/components/csrfInput"}}
+	{{/if}}
 </form>


### PR DESCRIPTION
Kleiner Fix, damit die OAuth-Signatur für LTI1.1 übereinstimmt. Der CSRF-Token wird nur dem Formular hinzugefügt, wenn es sich um LTI1.3 handelt, um dort Deep-Linking-Antworten zu handeln.