### PR TITLE
Hotfix/22.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "schulcloud-client",
-  "version": "22.2.4",
+  "version": "22.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-client",
-	"version": "22.2.4",
+	"version": "22.3.1",
 	"private": true,
 	"scripts": {
 		"start": "node ./bin/www",

--- a/views/lib/csrf_content.hbs
+++ b/views/lib/csrf_content.hbs
@@ -26,7 +26,9 @@
                 <form id="retryform" method="POST">
                     {{> "lib/components/csrfInput"}}
                     {{#each values}}
-                    <input type="hidden" name="{{this.name}}" value="{{this.value}}">
+                        {{#ifneq this.name "_csrf"}}
+                            <input type="hidden" name="{{../this.name}}" value="{{../this.value}}">
+                        {{/ifneq}}
                     {{/each}}
                     <a class="btn btn-primary" href="{{baseUrl}}" rel="noopener noreferrer" target="_blank" id="retrybtn">In
                         neuem Tab öffnen</a>


### PR DESCRIPTION
# #1648 should be merged first!

Ticket: https://ticketsystem.schul-cloud.org/browse/SC-3544


if the original form request contained a `_csrf` field, the token was also appended to the CSRF retry form. This resulted in multiple csrf tokens. I added some better error handling and prevented duplicate csrf tokens on the retry page.