### PR TITLE
update browserlist supported ranges

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,6 +28,8 @@ const nodemon = require('gulp-nodemon');
 const browserSync = require('browser-sync');
 const webpackConfig = require('./webpack.config');
 
+const browserlist = ['> 0.2%', 'last 10 version', 'not dead'];
+
 const baseScripts = [
 	'./static/scripts/jquery/jquery.min.js',
 	'./static/scripts/jquery/jquery.serialize-object.js',
@@ -119,7 +121,7 @@ gulp.task('styles', () => {
 				preserve: true,
 			}),
 			autoprefixer({
-				browsers: ['> 1%', 'not dead'],
+				browsers: browserlist,
 			}),
 		]))
 		.pipe(cleanCSS({
@@ -174,7 +176,7 @@ gulp.task('base-scripts', () => beginPipeAll(baseScripts)
 				'@babel/preset-env',
 				{
 					modules: false,
-					targets: '> 1%, not dead',
+					targets: browserlist.join(', '),
 				},
 			],
 		],
@@ -192,7 +194,7 @@ gulp.task('vendor-styles', () => beginPipe('./static/vendor/**/*.{css,sass,scss}
 	}))
 	.pipe(postcss([
 		autoprefixer({
-			browsers: ['> 1%', 'not dead'],
+			browsers: browserlist,
 		}),
 	]))
 	.pipe(cleanCSS({
@@ -211,7 +213,7 @@ gulp.task('vendor-scripts', () => beginPipe('./static/vendor/**/*.js')
 				'@babel/preset-env',
 				{
 					modules: false,
-					targets: '> 1%, not dead',
+					targets: browserlist.join(', '),
 				},
 			],
 		],

--- a/static/scripts/base.js
+++ b/static/scripts/base.js
@@ -14,9 +14,13 @@ function nodeListAddEventListener(events,
 	});
 	return this;
 }
-
 if (!NodeList.prototype.addEventListener) {
 	NodeList.prototype.addEventListener = nodeListAddEventListener;
+}
+
+// Polyfill for Edge 13 and other outdated browsers
+if (!NodeList.prototype.forEach) {
+	NodeList.prototype.forEach = Array.prototype.forEach;
 }
 
 // if is needed for IE11

--- a/static/scripts/dataprivacy/pin_input.js
+++ b/static/scripts/dataprivacy/pin_input.js
@@ -1,7 +1,3 @@
-if (!NodeList.prototype.forEach) {
-	NodeList.prototype.forEach = Array.prototype.forEach;
-}
-
 function buildPin(wrapper) {
 	let pin = '';
 	wrapper.querySelectorAll('.digit').forEach((input) => {

--- a/static/scripts/helpers/inputFromQuery.js
+++ b/static/scripts/helpers/inputFromQuery.js
@@ -2,10 +2,6 @@
 /* apply input from query */
 import { getQueryParameters } from './queryStringParameter';
 
-if (!NodeList.prototype.forEach) {
-	NodeList.prototype.forEach = Array.prototype.forEach;
-}
-
 window.addEventListener('DOMContentLoaded', () => {
 	const params = getQueryParameters();
 	Object.entries(params).forEach(([key, value]) => {


### PR DESCRIPTION
This should fix a lot of compatibility errors  from sentry and definetly should not hurt:
- https://sentry.schul-cloud.dev/schul-cloud/schul-cloud-client/issues/361

by simply adapting our build pipeline to output more compatible code:
- old: https://browserl.ist/?q=%3E+1%25%2C+not+dead
- new: https://browserl.ist/?q=%3E+0.2%25%2C+last+9+version%2C+not+dead