### PR TITLE
Hotfeature/gulp clear cache keep build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -255,6 +255,19 @@ gulp.task('clear', () => gulp
 	)
 	.pipe(rimraf()));
 
+// clear gulp cache without removing current build	
+gulp.task('clear-cache', () => gulp
+	.src(
+		[
+			'./.gulp-changed-smart.json',
+			'./.webpack-changed-plugin-cache/*',
+		],
+		{
+			read: false,
+		},
+	)
+	.pipe(rimraf()));
+
 // run all tasks, processing changed files
 gulp.task('build-all', [
 	'images',


### PR DESCRIPTION
# Checkliste

added `gulp clear-cache` which allows to clear the cache of gulp and webpack only without removal of build files. after `gulp clear-cache`, `gulp` is completely recreating the build files. 

if a build not consists most current files they can be updated without removal now.