### PR TITLE
hotfix - show info if cookies are blocked

### DIFF
--- a/config/default.schema.json
+++ b/config/default.schema.json
@@ -17,6 +17,11 @@
 			],
 			"description": "alert types"
 		},
+		"LOGIN_BLOCKED_COOKIES_NOTE": {
+			"type": "string",
+			"default": "Bitte aktiviere Cookies für diese Seite. Andernfalls ist ein Login aus technischen Gründen nicht möglich.",
+			"description": "text that is shown above the login form if cookies are blocked by the browser."
+		},
 		"FEATURE_CSRF_ENABLED": {
 			"type": "boolean",
 			"default": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "schulcloud-client",
-  "version": "22.5.4",
+  "version": "22.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17596,6 +17596,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
+    "storage-factory": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/storage-factory/-/storage-factory-0.1.0.tgz",
+      "integrity": "sha512-o2UQLqL6yiTT8jm7+fdh99tNSFBhlXd0HzHePqOC3OniHfXFhSDKvmHboVGSIPKJ8604/bBhT15Be5g7YpUZKw=="
     },
     "stream-browserify": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-client",
-	"version": "22.5.4",
+	"version": "22.5.5",
 	"private": true,
 	"scripts": {
 		"start": "node ./bin/www",
@@ -85,6 +85,7 @@
 		"serve-favicon": "^2.5.0",
 		"shortid": "^2.2.8",
 		"showdown": "^1.9.1",
+		"storage-factory": "^0.1.0",
 		"string-strip-html": "^3.2.0",
 		"string_decoder": "^1.0.1",
 		"truncate-html": "^1.0.0",

--- a/static/scripts/helpers/storage.js
+++ b/static/scripts/helpers/storage.js
@@ -1,0 +1,4 @@
+import { storageFactory } from 'storage-factory';
+
+export const local = storageFactory(() => localStorage);
+export const session = storageFactory(() => sessionStorage);

--- a/static/scripts/login.js
+++ b/static/scripts/login.js
@@ -1,15 +1,15 @@
-import './pwd.js';
+import './pwd';
 import './cleanup'; // see loggedin.js for loggedin users
+import * as storage from './helpers/storage';
 
-$(document).ready(function() {
-
+$(document).ready(() => {
 	// reset localStorage when new version is Published
 	const newVersion = 1;
-	const currentVersion = parseInt(localStorage.getItem('homepageVersion') || '0', 10);
+	const currentVersion = parseInt(storage.local.getItem('homepageVersion') || '0', 10);
 
-	if(currentVersion < newVersion){
-		localStorage.clear();
-		localStorage.setItem('homepageVersion', newVersion.toString());
+	if (currentVersion < newVersion) {
+		storage.local.clear();
+		storage.local.setItem('homepageVersion', newVersion.toString());
 	}
 
 	try {
@@ -22,9 +22,21 @@ $(document).ready(function() {
 	  \\ \\_\\ \\_\\ \\_\\    /\\_____\\   \\ \`\\____\\ \\____\\\\ \\_\\ \\_\\ \\____/ /\\____\\/_____/ \\ \\____//\\____\\ \\____/\\ \\____/\\ \\___,_\\
 	   \\/_/\\/_/\\/_/    \\/_____/    \\/_____/\\/____/ \\/_/\\/_/\\/___/  \\/____/         \\/___/ \\/____/\\/___/  \\/___/  \\/__,_ /
 	`);
-		console.log("Mit Node, React und Feathers verknüpfst du eher die Sprache Javascript als Englisch? Du suchst ein junges Team, lockere Atmosphäre und flache Hierarchien? Dann schau dir unsere Stellen an: https://schul-cloud.org/community#jobs");
-	} catch(e) {
+		console.log('Mit Node, React und Feathers verknüpfst du eher die Sprache Javascript als Englisch? Du suchst ein junges Team, lockere Atmosphäre und flache Hierarchien? Dann schau dir unsere Stellen an: https://schul-cloud.org/community#jobs');
+	} catch (e) {
 		// no log
+	}
+
+	const checkCookie = () => {
+		let { cookieEnabled } = navigator;
+		if (!cookieEnabled) {
+			document.cookie = 'testcookie';
+			cookieEnabled = document.cookie.indexOf('testcookie') !== -1;
+		}
+		return cookieEnabled;
+	};
+	if (!checkCookie()) {
+		$('.alert-cookies-blocked').removeClass('hidden');
 	}
 
     var $btnToggleProviers = $('.btn-toggle-providers');
@@ -64,7 +76,7 @@ $(document).ready(function() {
             systems.forEach(function(system) {
                 var systemAlias = system.alias ? ' (' + system.alias + ')' : '';
                 let selected;
-                if(localStorage.getItem('loginSystem') == system._id) {
+                if(storage.local.getItem('loginSystem') == system._id) {
                     selected = true;
                 }
                 $systems.append('<option ' + (selected ? 'selected': '') + ' value="' + system._id + '">' + system.type + systemAlias + '</option>');
@@ -94,14 +106,14 @@ $(document).ready(function() {
         const school = $school.val();
         const system = $systems.val();
         if (school) {
-            localStorage.setItem('loginSchool', school);
+            storage.local.setItem('loginSchool', school);
         } else {
-            localStorage.removeItem('loginSchool');
+            storage.local.removeItem('loginSchool');
         }
         if (system) {
-            localStorage.setItem('loginSystem', system);
+            storage.local.setItem('loginSystem', system);
         } else {
-            localStorage.removeItem('loginSystem');
+            storage.local.removeItem('loginSystem');
         }
     });
 
@@ -128,10 +140,10 @@ $(document).ready(function() {
     });
 
     // if stored login system - use that
-    if(localStorage.getItem('loginSchool')) {
+    if(storage.local.getItem('loginSchool')) {
         $btnToggleProviers.hide();
         $loginProviders.show();
-        $school.val(localStorage.getItem('loginSchool'));
+        $school.val(storage.local.getItem('loginSchool'));
         $school.trigger('chosen:updated');
         $school.trigger('change');
     }

--- a/views/authentication/forms/login.hbs
+++ b/views/authentication/forms/login.hbs
@@ -6,9 +6,7 @@
 
 			<div class="notification alert alert-danger alert-cookies-blocked hidden">
 				<div class="notification-content">
-					Dein Browser blockiert Cookies der {{@root.theme.short_title}}.
-					Eine Anmeldung ohne Cookies ist leider nicht möglich.
-					Bitte aktiviere Cookies für diese Seite.
+					{{{getConfig "LOGIN_BLOCKED_COOKIES_NOTE"}}}
 				</div>
 			</div>
 

--- a/views/authentication/forms/login.hbs
+++ b/views/authentication/forms/login.hbs
@@ -4,6 +4,14 @@
 		<div class="card-text form-wrapper">
 			{{> "lib/components/notification"}}
 
+			<div class="notification alert alert-danger alert-cookies-blocked hidden">
+				<div class="notification-content">
+					Dein Browser blockiert Cookies der {{@root.theme.short_title}}.
+					Eine Anmeldung ohne Cookies ist leider nicht möglich.
+					Bitte aktiviere Cookies für diese Seite.
+				</div>
+			</div>
+
 			<form method="post" action="/login" class="login-form">
 				<input type="hidden" name="redirect" value={{redirect}} />
 


### PR DESCRIPTION
- add check for blocked cookies and show info how to resolve
- make localStorage safe to access if storage is blocked (happens when cookies are blocked), otherwise the script failed to execute and the error for blocked cookies couldn't be shown.

https://michalzalecki.com/why-using-localStorage-directly-is-a-bad-idea/