### PR TITLE
SC-3472 extend dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .DS_Store
 .gitignore
 .webpack-changed-plugin-cache
+.gulp-changed-smart.json
 .idea
 .travis.yml*
 Dockerfile*


### PR DESCRIPTION
# Checkliste

adds the .gulp-changed-smart.json filepath into .dockerignore file to avoid caching issues 

@adrianjost it's not planned to copy precreated files into the docker containers, right? 

## Allgemein
- [x] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-3470

## Freigabe zum Review
- [x] WIP PR-Label entfernt, wenn die Checkliste abgearbeitet wurde

## Mehr
Weitere Informationen zur DoD [hier im Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
