### PR TITLE
SC-3785 link to course after course creation corrected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Fixed
 
+- SC-3785: link to course after course creation corrected
 - SC-3732: edit button was not visible for course teachers except the author on the task detail page
 - SC-3807: link "Methodenguide" in nbc addons
 - provide more formats for PTSans font to be compatible with more browsers

--- a/views/courses/create-course.hbs
+++ b/views/courses/create-course.hbs
@@ -252,7 +252,11 @@
 
               <div class="pull-right">
                 <a class="btn btn-secondary" href="/courses/add">{{$t "courses.add.link.addAnotherCourse"}}</a>
-                <a class="btn btn-primary" href="{{redirectUrl}}">{{$t "courses.add.link.giveExercises"}}</a>
+                {{#ifeq redirectUrl "/courses"}}
+                <a class="btn btn-primary" href="{{../redirectUrl}}">{{$t "courses.add.link.courseOverview"}}</a>
+                {{else}}
+                <a class="btn btn-primary" href="{{../redirectUrl}}">{{$t "courses.add.link.giveExercises"}}</a>
+                {{/ifeq}}
               </div>
             </section>
 

--- a/views/courses/create-course.hbs
+++ b/views/courses/create-course.hbs
@@ -252,11 +252,14 @@
 
               <div class="pull-right">
                 <a class="btn btn-secondary" href="/courses/add">{{$t "courses.add.link.addAnotherCourse"}}</a>
-                {{#ifeq redirectUrl "/courses"}}
-                <a class="btn btn-primary" href="{{../redirectUrl}}">{{$t "courses.add.link.courseOverview"}}</a>
-                {{else}}
-                <a class="btn btn-primary" href="{{../redirectUrl}}">{{$t "courses.add.link.giveExercises"}}</a>
-                {{/ifeq}}
+                
+                <a class="btn btn-primary" href="{{../redirectUrl}}">
+                   {{#ifeq redirectUrl "/courses"}}
+                      {{$t "courses.add.link.courseOverview"}}
+                   {{else}}
+                      {{$t "courses.add.link.giveExercises"}}
+                   {{/ifeq}}
+                </a>
               </div>
             </section>
 


### PR DESCRIPTION
# Checkliste

- SC-3785: link to course after course creation corrected


## Allgemein
- [x] Link zum Ticket https://ticketsystem.schul-cloud.org/browse/SC-3785
