### PR TITLE
fix(messenger): change chat window based on course url

### DIFF
--- a/static/scripts/chatLoggedin.js
+++ b/static/scripts/chatLoggedin.js
@@ -1,8 +1,8 @@
 function loadChatClient(session = null) {
-	let roomIdentifier = '';
+	let roomId = '';
 	const matches = RegExp('/courses/([^/]+).*').exec(window.location.pathname);
 	if (matches && matches.length >= 2) {
-		roomIdentifier = `#course_${matches[1]}:matrix.stomt.com`;
+		roomId = matches[1];
 	}
 
 	// create chat tag
@@ -11,9 +11,12 @@ function loadChatClient(session = null) {
 	riotBox.dataset.vectorIndexeddbWorkerScript = '/indexeddb-worker.js';
 	riotBox.dataset.vectorConfig = '/riot_config.json';
 	riotBox.dataset.vectorDefaultToggled = 'true';
-	riotBox.dataset.matrixRoomId = roomIdentifier;
 	riotBox.dataset.matrixLang = 'de';
 
+	if (session && roomId) {
+		const servername = session.userId.substr(session.userId.indexOf(':') + 1);
+		riotBox.dataset.matrixRoomId = `#course_${roomId}:${servername}`;
+	}
 	if (session) {
 		riotBox.dataset.matrixHomeserverUrl = session.homeserverUrl;
 		riotBox.dataset.matrixUserId = session.userId;

--- a/static/styles/lib/chatLoggedin.scss
+++ b/static/styles/lib/chatLoggedin.scss
@@ -31,6 +31,11 @@ $chat-color-secondary: hsl(hue($chat-color-primary), saturation($chat-color-prim
 		display: none !important;
 	}
 
+	// > do not ask to activate desktop notifications
+	.mx_MatrixToolbar {
+		display: none;
+	}
+
 
 	// Theme
 	// > Menu


### PR DESCRIPTION
The chat currently tries to enter the wrong chat rooms based on the course url, eg. on https://test.schul-cloud.org/courses/5e8ae0eec39059002b3b7e7a because the matrix server name was hardcoded.

This fix extracts the servername vom the matrix-userId instead.