### PR TITLE
use smart merge strategy

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,7 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        strict: true
+        strict: smart
   - name: auto merge when label is set
     conditions:
       - label!=WIP
@@ -19,7 +19,7 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-        strict: true
+        strict: smart
   - name: remove ready to merge label when merged
     conditions:
       - merged


### PR DESCRIPTION
Use mergifys smart merge strategy to save some CI execution time.
The smart merge mode will queue all prs to be merged and will only update one by on, so there will never be two PRs that compete against each other which would get merged first.

Documentation:
https://doc.mergify.io/actions.html#merge