### PR TITLE
Fix: delete indexedDB databases in all browsers

### DIFF
--- a/static/scripts/chatLoggedout.js
+++ b/static/scripts/chatLoggedout.js
@@ -8,14 +8,18 @@ function clearLocalstorage() {
 		});
 	}
 
-	// delete all indexedDB databases
+	// delete matrix indexedDB databases
 	if (window.indexedDB) {
-		window.indexedDB.databases()
-			.then((r) => {
-				for (let i = 0; i < r.length; i += 1) {
-					window.indexedDB.deleteDatabase(r[i].name);
-				}
-			});
+		// window.indexedDB.databases() is not available in all browsers
+		const databases = [
+			'logs',
+			'matrix-js-sdk:crypto',
+			'matrix-js-sdk:riot-web-sync',
+		];
+
+		for (let i = 0; i < databases.length; i += 1) {
+			window.indexedDB.deleteDatabase(databases[i]);
+		}
 	}
 }
 


### PR DESCRIPTION
# Description

## Changes
`window.indexedDB.databases()` was used to retrieve the active databases. But the function is not available in all browsers: https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory/databases
Therefor it replaced with a hardcoded list of IndexedDB database names used by the embedded messenger client.

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

ensures that user related data is deleted on logout

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
