### PR TITLE
hs/rename Lern-Nuggets

### DIFF
--- a/controllers/help.js
+++ b/controllers/help.js
@@ -77,7 +77,7 @@ router.get('/faq/people', (req, res, next) => {
 
 router.get('/lernNuggets', (req, res, next) => {
 	res.render('help/lern-nuggets', {
-		title: 'Lern-Nuggets',
+		title: 'Datenschutzkurs',
 		breadcrumb: [
 			{
 				title: 'Hilfebereich',

--- a/views/help/partials/help_nutzungshilfen.hbs
+++ b/views/help/partials/help_nutzungshilfen.hbs
@@ -30,7 +30,7 @@
 					"src": "https://lernen.cloud/courses/schulcloud2019"
 				},
 				{
-					"title": "Lern-Nuggets",
+					"title": "Datenschutzkurs",
 					"icon": "fa-cubes",
 					"src": "/help/lernNuggets"
 				},


### PR DESCRIPTION
simple wording change, rename "Lern-Nuggets" to "Datenschutzkurs", requested by Sophie Plötz via RC, so there is no ticket.
I would leave the URL as is so that we dont need to set up a redirection and it should fine to leave it.

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
