### PR TITLE
SC-4328: add flag to hide school messenger settings

### DIFF
--- a/config/default.schema.json
+++ b/config/default.schema.json
@@ -115,6 +115,11 @@
 			"default": "https://embed.stomt.com/bundles/10f5ebeaaad4e5220219/bundle.js",
 			"description": "Where to find the messenger dependencies."
 		},
+		"FEATURE_MESSENGER_SCHOOL_SETTINGS_VISIBLE": {
+			"type": "boolean",
+			"default": false,
+			"description": "Only if enabled, school admins can activate the messenger in their school setting"
+		},
 		"FEATURE_MESSENGER_SCHOOL_ROOM_ENABLED": {
 			"type": "boolean",
 			"default": false,

--- a/views/administration/school.hbs
+++ b/views/administration/school.hbs
@@ -220,7 +220,7 @@
 							<canvas id="logo-canvas" width="35" height="35" class="hidden"></canvas>
 						</div>
 
-						{{#ifConfig "FEATURE_MATRIX_MESSENGER_ENABLED" true}}
+						{{#ifConfig "FEATURE_MESSENGER_SCHOOL_SETTINGS_VISIBLE" true}}
 							<div class="form-group">
 								<label>
 									<input
@@ -269,7 +269,7 @@
 							{{/ifConfig}}
 						{{/ifConfig}}
 
-						{{#ifConfig "FEATURE_MATRIX_MESSENGER_ENABLED" false}}
+						{{#ifConfig "FEATURE_MESSENGER_SCHOOL_SETTINGS_VISIBLE" false}}
 							{{#if @root.ROCKETCHAT_SERVICE_ENABLED}}
 								<div class="form-group">
 									<label>

--- a/views/courses/edit-course.hbs
+++ b/views/courses/edit-course.hbs
@@ -195,7 +195,7 @@
 				</div>
 
 				{{#ifConfig "FEATURE_MATRIX_MESSENGER_ENABLED" true}}
-					{{#inArray "messenger" schoolData.features}}
+					{{#inArray "messenger" @root.schoolData.features}}
 						<div class="form-group">
 							<label>
 								<input type="checkbox" name="messenger" value="true" {{#inArray "messenger" ../course.features}}checked{{/inArray}}>

--- a/views/teams/edit-team.hbs
+++ b/views/teams/edit-team.hbs
@@ -31,7 +31,7 @@
                 </div>
 
                 {{#ifConfig "FEATURE_MATRIX_MESSENGER_ENABLED" true}}
-                    {{#inArray "messenger" schoolData.features}}
+                    {{#inArray "messenger" @root.schoolData.features}}
                         <div class="form-group">
                             <label>
                                 <input type="checkbox" name="messenger" value="true" {{#inArray "messenger" ../team.features}}checked{{/inArray}}>
@@ -43,7 +43,7 @@
 
                {{#ifConfig "FEATURE_MATRIX_MESSENGER_ENABLED" false}}
                     {{#if @root.ROCKETCHAT_SERVICE_ENABLED}}
-                        {{#inArray "rocketChat" schoolData.features}}
+                        {{#inArray "rocketChat" @root.schoolData.features}}
                             <div class="form-group">
                                 <label>
                                     <input type="checkbox" name="rocketChat" value="true" {{#inArray "rocketChat" ../team.features}}checked{{/inArray}}>


### PR DESCRIPTION
# Description

To allow a manuell rollout and onboarding of individual schools the settings to activate the messenger should be hidden in the UI until we set a feature flag.

## Links to Tickets or other pull requests
https://ticketsystem.schul-cloud.org/browse/SC-4328

## Changes
- add feature flag

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
 no changes

## Deployment
New feature flag `FEATURE_MESSENGER_SCHOOL_SETTINGS_VISIBLE` should stay disabled for now.

## New Repos, NPM pakages or vendor scripts
no changes

## Screenshots of UI changes
no changes

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
