### PR TITLE
SC-4845 - Schüler-importieren-button-missing

### DIFF
--- a/views/administration/students.hbs
+++ b/views/administration/students.hbs
@@ -92,11 +92,9 @@
                                         Schüler hinzufügen
                                     </button>
 
-                                    {{#inArray "Administrator" ../roleNames}}
                                         <a href="/administration/students/import" class="btn btn-secondary btn-import">
                                             Schüler importieren
                                         </a>
-                                    {{/inArray}}
                                 {{else}}
                                     {{> "lib/no-create-info"}}
                                 {{/userHasPermission}}

--- a/views/administration/teachers.hbs
+++ b/views/administration/teachers.hbs
@@ -71,11 +71,9 @@
                                     <button type="submit" class="btn btn-primary btn-add-modal">
                                         Lehrer hinzufügen
                                     </button>
-                                    {{#inArray "Administrator" ../roleNames}}
                                          <a href="/administration/teachers/import" class="btn btn-secondary btn-import">
                                             Lehrer importieren
                                         </a>
-                                    {{/inArray}}
                                 {{else}}
                                     {{> "lib/no-create-info"}}
                                 {{/userHasPermission}}


### PR DESCRIPTION
# Description
schuler/lehrer importieren button is not there for others users, only admin has it

## Links to Tickets or other pull requests

- https://ticketsystem.schul-cloud.org/browse/SC-4845

## Screenshot
![image](https://user-images.githubusercontent.com/40116220/83618115-4a5e8600-a58a-11ea-93ed-46e10da00d38.png)
