### PR TITLE
commented deletion of borders out; does it have any sideeffects?

### DIFF
--- a/static/vendor/ckeditor/config.js
+++ b/static/vendor/ckeditor/config.js
@@ -164,7 +164,7 @@ CKEDITOR.on('dialogDefinition', (ev) => {
 		const infoTab = dialogDefinition.getContents('info');
 		const border = infoTab.get('txtBorder');
 		border.default = 1;
-		infoTab.remove('txtBorder');
+		// infoTab.remove('txtBorder');
 		infoTab.remove('cmbAlign');
 		infoTab.remove('txtWidth');
 		infoTab.remove('txtHeight');


### PR DESCRIPTION
# Description

Stopped Border deletion inside of CKEditor.

## Links to Tickets or other pull requests
- https://ticketsystem.schul-cloud.org/browse/SC-4653

## Changes

This PR will restore borders inside of the CKEditor.

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

Only CSS-Changes, should be not security relevant

## Deployment

No extra ENV.

## New Repos, NPM pakages or vendor scripts

No REPOs, no NPM-Dependencies

## Screenshots of UI changes

![2020-06-08_11-11_ckeditorNotDeletingBorders](https://user-images.githubusercontent.com/1632106/84013555-5c209e80-a979-11ea-8a46-2bac932c3416.png)

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
