### PR TITLE
SC-4931 Fix Styling of PIN inputs in registration

### DIFF
--- a/views/registration/pin.hbs
+++ b/views/registration/pin.hbs
@@ -1,7 +1,3 @@
-{{#content "styles" mode="append"}}
-<link rel="stylesheet" href="/styles/registration/pin.css" />
-{{/content}}
-
 <div class="pin-input {{class}}">
   {{$t "registration.pin.input.verificationCode" }} <input class="combined-pin" type="text" name="{{name}}" pattern="{{pattern}}{ {{~digits~}} }" {{#if required}}required{{/if}} tabIndex="-1"/>
   {{#times digits}}

--- a/views/registration/registration-employee.hbs
+++ b/views/registration/registration-employee.hbs
@@ -6,6 +6,7 @@
   {{/content}}
   {{#content "styles" mode="append"}}
       <link rel="stylesheet" href="/styles/administration/dataprivacy.css"/>
+      <link rel="stylesheet" href="/styles/registration/pin.css" />
   {{/content}}
   {{#content "page"}}
     {{#embed "lib/forms/paginatedForm" sections=sectionNumber action="/registration/submit" method="post" class="registration-form parent" submit-label=($t "registration._registration.global.button.sendAndGetStarted")}}

--- a/views/registration/registration-parent.hbs
+++ b/views/registration/registration-parent.hbs
@@ -5,6 +5,7 @@
   {{/content}}
   {{#content "styles" mode="append"}}
       <link rel="stylesheet" href="/styles/administration/dataprivacy.css"/>
+      <link rel="stylesheet" href="/styles/registration/pin.css" />
   {{/content}}
   {{#content "page"}}
     {{#embed "lib/forms/paginatedForm" sections=sectionNumber action="/registration/submit" method="post" class="registration-form parent" submit-label=($t "registration._registration.global.button.sendAndGetStarted")}}

--- a/views/registration/registration-student.hbs
+++ b/views/registration/registration-student.hbs
@@ -5,6 +5,7 @@
   {{/content}}
   {{#content "styles" mode="append"}}
       <link rel="stylesheet" href="/styles/administration/dataprivacy.css"/>
+      <link rel="stylesheet" href="/styles/registration/pin.css" />
   {{/content}}
   {{#content "page"}}
     {{#embed "lib/forms/paginatedForm" sections=sectionNumber action="/registration/submit" method="post" class="registration-form student" submit-label=($t "registration._registration.global.button.sendAndGetStarted")}}


### PR DESCRIPTION
# Description
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
https://ticketsystem.schul-cloud.org/browse/SC-4931
<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.schul-cloud.org/browse/SC-????
-->

## Changes
The CSS for the inputs of the PIN in registration were missing. With this fix it looks exactly as before the CSP changes.
<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes
<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->
![Opera Momentaufnahme_2020-06-15_110600_localhost](https://user-images.githubusercontent.com/36112357/84639199-5afeec80-aef8-11ea-80e1-03d4ca485fd6.png)


## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
