### PR TITLE
SC-5206 - change-button-name

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -683,7 +683,7 @@
 				"courses": "Kurse",
 				"files": "Meine Dateien",
 				"lernstore": "Lern-Store",
-				"management": "Verwaltung",
+				"management": "Verwaltungsbereich",
 				"managementClasses": "Klassen",
 				"managementStudents": "Schüler:innen",
 				"managementTeachers": "Lehrer:innen",


### PR DESCRIPTION
# Description
I have tried on master, develop, on staging and niedersachsen. On every page there is button Verwaltung for teacher.

This button is missing on schul-cloud.org because it has another release version than others (https://dashboard.schul-cloud.dev/#/home/dashboard)

So button is there, but schulcloud.org needs to be upgraded to new version.


## Links to Tickets or other pull requests
- https://ticketsystem.schul-cloud.org/browse/SC-5206

## Changes
Changed name of button Verwaltung to Verwaltungsbereich