### PR TITLE
i18n SC-5262 Bugfix: content sometimes loads before initialization

### DIFF
--- a/static/scripts/i18n.js
+++ b/static/scripts/i18n.js
@@ -7,13 +7,14 @@ import pkg from '../../package.json';
 const userLanguage = document.querySelector('html').getAttribute('lang');
 
 // mock method. used until language keys are loaded. (not perfect, but at least it works for now)
-window.$t = key => key;
+window.$t = (key) => key;
 
 i18next
 	.use(Backend)
 	.init({
+		initImmediate: false,
 		lng: userLanguage,
-		fallbackLng: ['de', 'en'].filter(lng => lng !== userLanguage),
+		fallbackLng: ['de', 'en'].filter((lng) => lng !== userLanguage),
 		backend: {
 			backends: [
 				LocalStorageBackend, // primary


### PR DESCRIPTION
Ticket: https://ticketsystem.schul-cloud.org/browse/SC-5262

i18n-initialization is sometimes slower than loading the page content (for example in static scripts), which results in only displaying the keys. With this PR I've added the option `initImmediate: false`. This is responsible for initializing i18n synchronously and therefore avoid the bug.