### PR TITLE
Feature/SC-5327 remove bereich from navigation items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ privacy policy should be confirmed by every school user
 
 ### Changed
 
+- SC-5327 removed 'bereich' suffix from navigation items
+
 ### Removed
 
 ## [23.4.4] - 2020-06-18

--- a/locales/de.json
+++ b/locales/de.json
@@ -685,7 +685,7 @@
 				"courses": "Kurse",
 				"files": "Meine Dateien",
 				"lernstore": "Lern-Store",
-				"management": "Verwaltungsbereich",
+				"management": "Verwaltung",
 				"managementClasses": "Klassen",
 				"managementStudents": "Schüler:innen",
 				"managementTeachers": "Lehrer:innen",


### PR DESCRIPTION
Removed `bereich` suffix from left navigation bar item `Verwaltung` to keep it short