### PR TITLE
Feature/SC-5289 Open tools in new tab if set

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -516,7 +516,7 @@
 					"noTools": "Keine Tools.",
 					"videoConferenceBBB": "Videokonferenz BigBlueButton",
 					"videoConferenceNotStartedYet": "Videokonferenz wurde noch nicht gestartet",
-					"opensInNewTab": "neues Tab"
+					"opensInNewTab": "neuer Tab"
 				}
 			},
 			"topic": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -515,7 +515,8 @@
 					"descriptionAddToolToCourse": "Füge hier interaktive Tools, wie GeoGebra oder CodeOcean, einem Kurs hinzu.",
 					"noTools": "Keine Tools.",
 					"videoConferenceBBB": "Videokonferenz BigBlueButton",
-					"videoConferenceNotStartedYet": "Videokonferenz wurde noch nicht gestartet"
+					"videoConferenceNotStartedYet": "Videokonferenz wurde noch nicht gestartet",
+					"opensInNewTab": "neues Tab"
 				}
 			},
 			"topic": {

--- a/static/scripts/base.js
+++ b/static/scripts/base.js
@@ -257,9 +257,13 @@ $(document).ready(() => {
 	const $modals = $('.modal');
 	const $deleteModal = $('.delete-modal');
 
-	const nextPage = (href) => {
+	const nextPage = (href, blank = false) => {
 		if (href) {
-			window.location.href = href;
+			if (blank) {
+				window.open(href);
+			} else {
+				window.location.href = href;
+			}
 		} else {
 			window.location.reload();
 		}
@@ -339,7 +343,7 @@ $(document).ready(() => {
 
 	// Window Location Link
 	$('.locationlink').on('click', function locationLink() {
-		nextPage($(this).attr('data-loclink'));
+		nextPage($(this).attr('data-loclink'), !!$(this).attr('data-blank'));
 	});
 
 	// Print Button

--- a/views/courses/components/tools.hbs
+++ b/views/courses/components/tools.hbs
@@ -3,8 +3,15 @@
 		<div class="list-group" data-courseId="{{@root/_id}}">
 			{{#if ltiToolIds}}
 			{{#each ltiToolIds}}
-			<div class="card card-block card-tool locationlink {{#if this.isBBB}} bbbTool {{/if}}" {{#unless this.isBBB}}
-				data-loclink="/courses/{{../_id}}/tools/show/{{this._id}}" {{/unless}}>
+			<div class="card card-block card-tool locationlink {{#if this.isBBB}} bbbTool {{/if}}"
+			{{#unless this.isBBB}}
+				{{#if this.openNewTab}}
+					data-blank="true"
+					data-loclink="{{#if this.isLocal}}{{this.url}}{{else}}/courses/{{@root/_id}}/tools/run/{{this._id}}{{/if}}"
+				{{else}}
+					data-loclink="/courses/{{../_id}}/tools/show/{{this._id}}"
+				{{/if}}
+			{{/unless}}>
 				{{#unless this.isBBB}}
 				<div class="card-title-directory">
 					{{#if logo_url}}
@@ -14,6 +21,10 @@
 					{{/if}}
 
 					<span>{{this.name}}</span>
+
+					{{#if this.openNewTab}}
+						<span style="font-size: 80%;" class="externalLink">({{$t "courses._course.tools.text.opensInNewTab"}})</span>
+					{{/if}}
 
 					{{#if this.isBBB}}
 					<a class="bbbTool-reload-icon">

--- a/views/courses/forms/form-tools.hbs
+++ b/views/courses/forms/form-tools.hbs
@@ -34,3 +34,4 @@
 <input type="hidden" name="courseId" value="{{courseId}}" data-force-value="true" />
 <input type="hidden" name="originTool" />
 <input type="hidden" name="privacy_permission" value="{{privacy_permission}}" />
+<input type="hidden" name="openNewTab" value="{{openNewTab}}" />


### PR DESCRIPTION
# Description
If configured in SHD tools should be opened directly in a new tab.

## Links to Tickets or other pull requests
https://ticketsystem.schul-cloud.org/browse/SC-5289

Requires: https://github.com/schul-cloud/schulcloud-server/pull/1475

## Changes
Add hint to affected tools and directly show frame content when opening the tool in course section.

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
Not relevant.

## Deployment
-

## New Repos, NPM pakages or vendor scripts
-

## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/22246303/86135425-16c03e80-baeb-11ea-8433-6a3a61cd90ef.png)


## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
