### PR TITLE
Update pullapprove to the group of gernal

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -19,7 +19,7 @@ notifications:
   comment: "The review is completed. Thanks @{{ author }}, we'll take it from here."
 
 groups:
-  sc-admins:
+  general:
     reviewers:
       teams:
       - general


### PR DESCRIPTION
# Description
Next step on the new group plann for github.
Change the group to gerneral who is requeierd by pullaporve to approve pull request.

## Links to Tickets or other pull requests
hpi-schul-cloud/schulcloud-server#3145
hpi-schul-cloud/nuxt-client#1950
hpi-schul-cloud/end-to-end-tests#361

## Changes
Change the group to gerneral who is requeierd by pullaporve to approve pull request.

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
