### PR TITLE
BC-11261 - fix room registration edge case

### DIFF
--- a/controllers/registration.js
+++ b/controllers/registration.js
@@ -351,16 +351,16 @@ router.get(['/registration/:classOrSchoolId/:byRole'], async (req, res) => {
 	const correctID = await validID();
 
 	const user = {};
-	const importHash = req.query.importHash || req.query.id; // req.query.id is deprecated
+	user.importHash = req.query.importHash || req.query.id; // req.query.id is deprecated
 	user.classOrSchoolId = req.params.classOrSchoolId;
 
 	invalid = await checkValidRegistration(req);
 
 	await resetThemeForPrivacyDocuments(req, res);
 
-	if (importHash) {
+	if (user.importHash) {
 		const response = await api(req).get(
-			`/users/linkImport/${importHash}`,
+			`/users/linkImport/${user.importHash}`,
 		);
 		Object.assign(user, response);
 	}

--- a/controllers/registration.js
+++ b/controllers/registration.js
@@ -362,10 +362,6 @@ router.get(['/registration/:classOrSchoolId/:byRole'], async (req, res) => {
 		const response = await api(req).get(
 			`/users/linkImport/${importHash}`,
 		);
-		if (!response.userId) {
-			// invalid import hash return error code
-			return res.status(400).send(res.$t('registration.text.invalidLink'));
-		}
 		Object.assign(user, response);
 	}
 

--- a/controllers/registration.js
+++ b/controllers/registration.js
@@ -363,9 +363,8 @@ router.get(['/registration/:classOrSchoolId/:byRole'], async (req, res) => {
 			`/users/linkImport/${importHash}`,
 		);
 		if (!response.userId) {
-			// invalid import hash, render page without user data and show error message
-			// todo: create proper error message / screen
-			return res.sendStatus(400);
+			// invalid import hash return error code
+			return res.status(400).send(res.$t('registration.text.invalidImportHash'));
 		}
 		Object.assign(user, response);
 	}

--- a/controllers/registration.js
+++ b/controllers/registration.js
@@ -364,7 +364,7 @@ router.get(['/registration/:classOrSchoolId/:byRole'], async (req, res) => {
 		);
 		if (!response.userId) {
 			// invalid import hash return error code
-			return res.status(400).send(res.$t('registration.text.invalidImportHash'));
+			return res.status(400).send(res.$t('registration.text.invalidLink'));
 		}
 		Object.assign(user, response);
 	}

--- a/controllers/registration.js
+++ b/controllers/registration.js
@@ -192,10 +192,10 @@ const schoolExists = async (req, schoolId) => {
 
 router.get(['/registration/:classOrSchoolId/byparent', '/registration/:classOrSchoolId/byparent/:sso/:accountId'],
 	async (req, res, next) => {
-		if (!RegExp('^[0-9a-fA-F]{24}$').test(req.params.classOrSchoolId)) {
+		if (!/^[0-9a-fA-F]{24}$/.test(req.params.classOrSchoolId)) {
 			if (
 				req.params.sso
-				&& !RegExp('^[0-9a-fA-F]{24}$').test(req.params.accountId)
+				&& !/^[0-9a-fA-F]{24}$/.test(req.params.accountId)
 			) {
 				return res.sendStatus(400);
 			}
@@ -325,10 +325,10 @@ router.get(['/registration/:classOrSchoolId/bystudent', '/registration/:classOrS
 	});
 
 router.get(['/registration/:classOrSchoolId/:byRole'], async (req, res) => {
-	if (!RegExp('^[0-9a-fA-F]{24}$').test(req.params.classOrSchoolId)) {
+	if (!/^[0-9a-fA-F]{24}$/.test(req.params.classOrSchoolId)) {
 		if (
 			req.params.sso
-			&& !RegExp('^[0-9a-fA-F]{24}$').test(req.params.accountId)
+			&& !/^[0-9a-fA-F]{24}$/.test(req.params.accountId)
 		) {
 			return res.sendStatus(400);
 		}
@@ -340,7 +340,7 @@ router.get(['/registration/:classOrSchoolId/:byRole'], async (req, res) => {
 			try {
 				await api(req).get(`/classes/${req.params.classOrSchoolId}`);
 				idExists = true;
-			} catch (e) {
+			} catch {
 				idExists = false;
 			}
 		}
@@ -351,17 +351,22 @@ router.get(['/registration/:classOrSchoolId/:byRole'], async (req, res) => {
 	const correctID = await validID();
 
 	const user = {};
-	user.importHash = req.query.importHash || req.query.id; // req.query.id is deprecated
+	const importHash = req.query.importHash || req.query.id; // req.query.id is deprecated
 	user.classOrSchoolId = req.params.classOrSchoolId;
 
 	invalid = await checkValidRegistration(req);
 
 	await resetThemeForPrivacyDocuments(req, res);
 
-	if (user.importHash) {
+	if (importHash) {
 		const existingUser = await api(req).get(
-			`/users/linkImport/${user.importHash}`,
+			`/users/linkImport/${importHash}`,
 		);
+		if (!existingUser.userId) {
+			// invalid import hash, render page without user data and show error message
+			// todo: create proper error message / screen
+			return res.sendStatus(400);
+		}
 		Object.assign(user, existingUser);
 	}
 

--- a/controllers/registration.js
+++ b/controllers/registration.js
@@ -359,15 +359,15 @@ router.get(['/registration/:classOrSchoolId/:byRole'], async (req, res) => {
 	await resetThemeForPrivacyDocuments(req, res);
 
 	if (importHash) {
-		const existingUser = await api(req).get(
+		const response = await api(req).get(
 			`/users/linkImport/${importHash}`,
 		);
-		if (!existingUser.userId) {
+		if (!response.userId) {
 			// invalid import hash, render page without user data and show error message
 			// todo: create proper error message / screen
 			return res.sendStatus(400);
 		}
-		Object.assign(user, existingUser);
+		Object.assign(user, response);
 	}
 
 	let needConsent = true;


### PR DESCRIPTION
# Description
In order to make team- and room-registrations-processes for the same e-mail-address work correctly together:
- respond with error, if team-registration-link is opened when a room registration for (a user with) the same e-mail-address was already completed

## Links to Tickets or other pull requests
BC-11261
https://github.com/hpi-schul-cloud/schulcloud-server/pull/6290

## Changes

## Data Security

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
