### PR TITLE
BC-12106 - fix classes administration school year

### DIFF
--- a/controllers/administration.js
+++ b/controllers/administration.js
@@ -1038,14 +1038,20 @@ const renderClassEdit = (req, res, next) => {
 					const selectableSchoolYears = getSelectableYears(res.locals.currentSchoolData);
 					const selectableSchoolYearsIds = new Set(selectableSchoolYears.map((year) => year._id));
 
-					let schoolYears = res.locals.currentSchoolData.years.schoolYears
-						.sort((a, b) => b.startDate.localeCompare(a.startDate));
-					schoolYears = schoolYears.map((year) => {
-						if (!selectableSchoolYearsIds.has(year._id)) {
-							return { ...year, disabled: true };
-						}
-						return year;
-					});
+					const schoolYears = res.locals.currentSchoolData.years.schoolYears
+						.sort((a, b) => b.startDate.localeCompare(a.startDate))
+						.map((year) => {
+							if (!selectableSchoolYearsIds.has(year._id)) {
+								return { ...year, disabled: true };
+							}
+							if (currentClass && currentClass.year === year._id) {
+								return { ...year, selected: true };
+							}
+							if (mode === 'create' && res.locals.currentSchoolData.years.activeYear._id === year._id) {
+								return { ...year, selected: true };
+							}
+							return year;
+						});
 
 					const isAdmin = res.locals.currentUser.permissions.includes(
 						'ADMIN_VIEW',
@@ -1066,14 +1072,6 @@ const renderClassEdit = (req, res, next) => {
 
 					let isCustom = false;
 					let isUpgradable = false;
-
-					if (mode === 'create') {
-						schoolYears.forEach((schoolyear) => {
-							if (res.locals.currentSchoolData.years.activeYear._id === schoolyear._id) {
-								schoolyear.selected = true;
-							}
-						});
-					}
 					if (currentClass) {
 						// preselect already selected teachers
 						teachers.forEach((t) => {
@@ -1085,11 +1083,6 @@ const renderClassEdit = (req, res, next) => {
 							// eslint-disable-next-line eqeqeq
 							if (currentClass.gradeLevel == g.grade) {
 								g.selected = true;
-							}
-						});
-						schoolYears.forEach((schoolyear) => {
-							if (currentClass.year === schoolyear._id) {
-								schoolyear.selected = true;
 							}
 						});
 						if (currentClass.gradeLevel) {

--- a/controllers/administration.js
+++ b/controllers/administration.js
@@ -1066,6 +1066,14 @@ const renderClassEdit = (req, res, next) => {
 
 					let isCustom = false;
 					let isUpgradable = false;
+
+					if (mode === 'create') {
+						schoolYears.forEach((schoolyear) => {
+							if (res.locals.currentSchoolData.years.activeYear._id === schoolyear._id) {
+								schoolyear.selected = true;
+							}
+						});
+					}
 					if (currentClass) {
 						// preselect already selected teachers
 						teachers.forEach((t) => {

--- a/controllers/administration.js
+++ b/controllers/administration.js
@@ -1035,12 +1035,18 @@ const renderClassEdit = (req, res, next) => {
 			const mode = req.locals.mode;
 			Promise.all(promises).then(
 				([teachers, gradeLevels, currentClass]) => {
-					const schoolyears = getSelectableYears(res.locals.currentSchoolData);
+					const selectableSchoolYears = getSelectableYears(res.locals.currentSchoolData);
+					const selectableSchoolYearsIds = new Set(selectableSchoolYears.map((year) => year._id));
 
-					const allSchoolYears = res.locals.currentSchoolData.years.schoolYears
+					let schoolYears = res.locals.currentSchoolData.years.schoolYears
 						.sort((a, b) => b.startDate.localeCompare(a.startDate));
+					schoolYears = schoolYears.map((year) => {
+						if (!selectableSchoolYearsIds.has(year._id)) {
+							return { ...year, disabled: true };
+						}
+						return year;
+					});
 
-					const lastDefinedSchoolYearId = (allSchoolYears[0] || {})._id;
 					const isAdmin = res.locals.currentUser.permissions.includes(
 						'ADMIN_VIEW',
 					);
@@ -1073,7 +1079,7 @@ const renderClassEdit = (req, res, next) => {
 								g.selected = true;
 							}
 						});
-						schoolyears.forEach((schoolyear) => {
+						schoolYears.forEach((schoolyear) => {
 							if (currentClass.year === schoolyear._id) {
 								schoolyear.selected = true;
 							}
@@ -1089,7 +1095,8 @@ const renderClassEdit = (req, res, next) => {
 						}
 
 						if (currentClass.year) {
-							isUpgradable = (lastDefinedSchoolYearId !== (currentClass.year || {}))
+							isUpgradable = (res.locals.currentSchoolData.years.nextYear || {})._id !== currentClass.year
+								&& selectableSchoolYearsIds.has(currentClass.year)
 								&& currentClass.gradeLevel
 								&& currentClass.gradeLevel !== 13
 								&& !currentClass.successor;
@@ -1118,7 +1125,7 @@ const renderClassEdit = (req, res, next) => {
 						edit: mode !== 'create',
 						isUpgradable,
 						mode,
-						schoolyears,
+						schoolYears,
 						teachers,
 						class: currentClass,
 						gradeLevels,

--- a/controllers/administration.js
+++ b/controllers/administration.js
@@ -1041,16 +1041,14 @@ const renderClassEdit = (req, res, next) => {
 					const schoolYears = res.locals.currentSchoolData.years.schoolYears
 						.sort((a, b) => b.startDate.localeCompare(a.startDate))
 						.map((year) => {
-							if (!selectableSchoolYearsIds.has(year._id)) {
-								return { ...year, disabled: true };
-							}
-							if (currentClass && currentClass.year === year._id) {
-								return { ...year, selected: true };
-							}
-							if (mode === 'create' && res.locals.currentSchoolData.years.activeYear._id === year._id) {
-								return { ...year, selected: true };
-							}
-							return year;
+							const selected = (currentClass && currentClass.year === year._id)
+								|| (mode === 'create' && res.locals.currentSchoolData.years.activeYear._id === year._id);
+							const disabled = !selectableSchoolYearsIds.has(year._id);
+							return {
+								...year,
+								...(disabled ? { disabled: true } : {}),
+								...(selected ? { selected: true } : {}),
+							};
 						});
 
 					const isAdmin = res.locals.currentUser.permissions.includes(

--- a/views/administration/forms/form-classes-edit.hbs
+++ b/views/administration/forms/form-classes-edit.hbs
@@ -21,8 +21,9 @@
 	<label>{{$t "administration.global.label.schoolYear" }} <sup>*</sup></label>
 	<select class="linked" name="schoolyear" data-linktext data-placeholder="Schuljahr auswählen"
 		{{#ifCond edit '&&' isCustom}}{{#unless @root.class.keepYear}}disabled {{/unless}}{{/ifCond}}>
-		{{#each schoolyears}}
-			<option value="{{this._id}}" {{#if this.selected}}selected{{else}}{{#ifeq ../mode "upgrade"}}disabled{{/ifeq}}{{/if}}>
+        <option value>{{$t "administration.global.label.chooseSchoolYear" }}</option>
+		{{#each schoolYears}}
+			<option value="{{this._id}}" {{#if this.disabled}}disabled{{/if}} {{#if this.selected}}selected{{else}}{{#ifeq ../mode "upgrade"}}disabled{{/ifeq}}{{/if}}>
 				{{this.name}}
 			</option>
 		{{/each}}
@@ -90,7 +91,7 @@
 			<p>{{$t "administration.classes.text.className" }}
 				<span data-from="grade"></span><span data-from="classsuffix"></span>
 			</p>
-			<p>{{$t "administration.global.label.schoolYear" }}:  <span data-from="schoolyear" /></p>
+			<p>{{$t "administration.global.label.schoolYear" }}:  <span data-from="schoolyear" /> {{ schoolyear }} </p>
 		</div>
 		<div class="class-custom {{#unless isCustom}}hidden{{/unless}}">
 			<p>{{$t "administration.classes.text.className" }}

--- a/views/administration/forms/form-classes-edit.hbs
+++ b/views/administration/forms/form-classes-edit.hbs
@@ -21,7 +21,7 @@
 	<label>{{$t "administration.global.label.schoolYear" }} <sup>*</sup></label>
 	<select class="linked" name="schoolyear" data-linktext data-placeholder="Schuljahr auswählen"
 		{{#ifCond edit '&&' isCustom}}{{#unless @root.class.keepYear}}disabled {{/unless}}{{/ifCond}}>
-        <option value>{{$t "administration.global.label.chooseSchoolYear" }}</option>
+		<option disabled value="">{{$t "administration.global.label.chooseSchoolYear" }}</option>
 		{{#each schoolYears}}
 			<option value="{{this._id}}" {{#if this.disabled}}disabled{{/if}} {{#if this.selected}}selected{{else}}{{#ifeq ../mode "upgrade"}}disabled{{/ifeq}}{{/if}}>
 				{{this.name}}
@@ -91,7 +91,7 @@
 			<p>{{$t "administration.classes.text.className" }}
 				<span data-from="grade"></span><span data-from="classsuffix"></span>
 			</p>
-			<p>{{$t "administration.global.label.schoolYear" }}:  <span data-from="schoolyear" /> {{ schoolyear }} </p>
+			<p>{{$t "administration.global.label.schoolYear" }}:  <span data-from="schoolyear" /></p>
 		</div>
 		<div class="class-custom {{#unless isCustom}}hidden{{/unless}}">
 			<p>{{$t "administration.classes.text.className" }}


### PR DESCRIPTION
# Description

School years selection in Class Management was faulty
If the class year is not in the pprevious, current or next year.
Also moving class to next school year was not behaving correctly.

 
## Links to Tickets or other pull requests
BC-12106 


## Changes
List all available schools years but allow only previous, current or next year to be selected.
Migrate class to next school year is possible only if the class is current or previous year.

## Data Security


## Deployment


## New Repos, NPM packages or vendor scripts


## Screenshots of UI changes


## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
