### PR TITLE
Implement Brandenburg OAuth Schulconnex and PKCE support

### DIFF
--- a/controllers/login.js
+++ b/controllers/login.js
@@ -167,8 +167,9 @@ const redirectOAuth2Authentication = async (req, res, systemId, migration, redir
 	}
 
 	const state = shortid.generate();
+	const { codeVerifier, codeChallenge } = authHelper.generatePkcePair();
 
-	const authenticationUrl = authHelper.getAuthenticationUrl(oauthConfig, state, migration, loginHint);
+	const authenticationUrl = authHelper.getAuthenticationUrl(oauthConfig, state, migration, loginHint, codeChallenge);
 
 	req.session.oauth2State = {
 		state,
@@ -178,6 +179,7 @@ const redirectOAuth2Authentication = async (req, res, systemId, migration, redir
 		migration,
 		logoutEndpoint: oauthConfig.logoutEndpoint,
 		provider: oauthConfig.provider,
+		codeVerifier,
 	};
 
 	res.redirect(authenticationUrl.toString());
@@ -233,6 +235,7 @@ router.get('/login/oauth2-callback', async (req, res) => {
 		code,
 		systemId: oauth2State.systemId,
 		redirectUri: authHelper.oauth2RedirectUri,
+		codeVerifier: oauth2State.codeVerifier,
 	};
 
 	let loginResponse;

--- a/helpers/authentication.js
+++ b/helpers/authentication.js
@@ -449,7 +449,19 @@ const login = (payload = {}, req, res, next) => {
 
 const oauth2RedirectUri = new URL('/login/oauth2-callback', Configuration.get('HOST')).toString();
 
-const getAuthenticationUrl = (oauthConfig, state, migration, loginHint) => {
+// PKCE - Brandenburg's SchulConnex IDP
+// requires a code_challenge on the authorization request and rejects it
+// otherwise. Generating and sending PKCE params is backwards compatible with
+// IdPs that don't require it (unknown/unused params are ignored), so this is
+// applied for every oauth2 login.
+const generatePkcePair = () => {
+	const codeVerifier = crypto.randomBytes(32).toString('base64url');
+	const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
+
+	return { codeVerifier, codeChallenge };
+};
+
+const getAuthenticationUrl = (oauthConfig, state, migration, loginHint, codeChallenge) => {
 	const authenticationUrl = new URL(oauthConfig.authEndpoint);
 
 	authenticationUrl.searchParams.append('client_id', oauthConfig.clientId);
@@ -468,6 +480,11 @@ const getAuthenticationUrl = (oauthConfig, state, migration, loginHint) => {
 
 	if (oauthConfig.idpHint) {
 		authenticationUrl.searchParams.append('kc_idp_hint', oauthConfig.idpHint);
+	}
+
+	if (codeChallenge) {
+		authenticationUrl.searchParams.append('code_challenge', codeChallenge);
+		authenticationUrl.searchParams.append('code_challenge_method', 'S256');
 	}
 
 	return authenticationUrl.toString();
@@ -599,6 +616,7 @@ module.exports = {
 	generatePassword,
 	generateConsentPassword,
 	oauth2RedirectUri,
+	generatePkcePair,
 	getAuthenticationUrl,
 	loginUser,
 	migrateUser,


### PR DESCRIPTION
# Description
Integrates Proof Key for Code Exchange  into the OAuth2 login flow and generates a code challenge and verifier for every authentication request. The verifier is stored in the session and sent during the callback to authorize the token exchange.

## Links to Tickets or other pull requests
https://github.com/FWU-DE/svs-local-setup/pull/8
https://fwu-de.atlassian.net/browse/SVSINT-222
https://fwu-de.atlassian.net/browse/SVSINT-326

## Changes
This PR changes the login page to support a Brandenburg Schulconnex OAuth account. It redirects the user (developer) to the Schulconnex landing page to log in, and then handles the corresponding redirect in the main SchulCloud UI. 

## Data Security
No user data is being logged, the endpoint specifics should be stored locally only in an .env file. Test user data has been provided by the Brandenburg development team and this is seeded into MongoDB before server start. 

## Deployment
Local development only, no new deployments required.

## New Repos, NPM packages or vendor scripts
None.

## Screenshots of UI changes
None - Re-using existing SC_THEME configurations. 

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
- [ ] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)